### PR TITLE
Updated ListResult to accurately implement declared intefaces

### DIFF
--- a/lib/ChargeBee/ListResult.php
+++ b/lib/ChargeBee/ListResult.php
@@ -9,7 +9,7 @@ class ChargeBee_ListResult implements Countable, ArrayAccess, Iterator
 
 	protected $_items;
 	
-	private $_index;
+	private $_index = 0;
 	
   function __construct($response, $nextOffset)
   {
@@ -40,22 +40,22 @@ class ChargeBee_ListResult implements Countable, ArrayAccess, Iterator
 	//Implementation for ArrayAccess functions
 	public function offsetSet($k, $v)
   {
-    $this->$k = $v;
+    $this->_items[$k] = $v;
   }
 
   public function offsetExists($k)
   {
-    return isset($this->$k);
+    return isset($this->_items[$k]);
   }
 
   public function offsetUnset($k)
   {
-    unset($this->$k);
+    unset($this->_items[$k]);
   }
 
   public function offsetGet($k)
   {
-    return isset($this->list[$k]) ? $this->list[$k] : null;
+    return isset($this->_items[$k]) ? $this->_items[$k] : null;
   }
 
   //Implementation for Iterator functions


### PR DESCRIPTION
Switched to use actual variables (i.e. $this->_items) instead of undeclared variables ($this->list) to that offsetGet, etc. actually retrieve values (instead of null)
