### PR TITLE
Replacing cURL with Guzzle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,10 @@
 
 # Ignore the SimpleTest library
 /test/simpletest/
+
+# Ignore IntelliJ project files
+/.idea/
+
+# Ignore Composer artifacts
+/composer.phar
+/vendor/

--- a/composer.json
+++ b/composer.json
@@ -7,5 +7,8 @@
     "homepage": "https://github.com/chargebee/chargebee-php",
     "autoload": {
         "files": ["lib/ChargeBee.php"]
+    },
+    "require": {
+        "guzzlehttp/guzzle": "^6.2"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,250 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "hash": "53c2c67118c1614395321e29ce985475",
+    "content-hash": "7a09cad507b2fe65f09937c5f40f30c5",
+    "packages": [
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "6.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "f4db5a78a5ea468d4831de7f0bf9d9415e348699"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/f4db5a78a5ea468d4831de7f0bf9d9415e348699",
+                "reference": "f4db5a78a5ea468d4831de7f0bf9d9415e348699",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/promises": "^1.0",
+                "guzzlehttp/psr7": "^1.4",
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "^4.0 || ^5.0",
+                "psr/log": "^1.0"
+            },
+            "suggest": {
+                "psr/log": "Required for using the Log middleware"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.2-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "rest",
+                "web service"
+            ],
+            "time": "2017-06-22 18:50:49"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "v1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "time": "2016-12-20 10:07:11"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
+                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "psr/http-message": "~1.0"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "time": "2017-03-20 17:10:46"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2016-08-06 14:39:51"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/lib/ChargeBee.php
+++ b/lib/ChargeBee.php
@@ -1,7 +1,7 @@
 <?php
 
 function checkExtentions() {
-    $extensions = array('curl', 'json');
+    $extensions = array('json');
     foreach ($extensions AS $e) {
         if (!extension_loaded($e)) {
             throw new Exception('ChargeBee requires the ' . $e . ' extension.');
@@ -41,7 +41,7 @@ require(dirname(__FILE__) . '/ChargeBee/Exceptions/OperationFailedException.php'
 require(dirname(__FILE__) . '/ChargeBee/Exceptions/InvalidRequestException.php');
 
 require(dirname(__FILE__) . '/ChargeBee/Request.php');
-require(dirname(__FILE__) . '/ChargeBee/Curl.php');
+require(dirname(__FILE__) . '/ChargeBee/Guzzle.php');
 
 require(dirname(__FILE__) . '/ChargeBee/Result.php');
 require(dirname(__FILE__) . '/ChargeBee/ListResult.php');

--- a/lib/ChargeBee/Exceptions/IOException.php
+++ b/lib/ChargeBee/Exceptions/IOException.php
@@ -10,6 +10,11 @@ class ChargeBee_IOException extends Exception {
     }
 
     public function getCurlErrorCode() {
+        trigger_error('Use ' . ChargeBee_IOException::class . '::getErrorCode() instead', E_USER_DEPRECATED);
+        return $this->getErrorCode();
+    }
+
+    public function getErrorCode() {
         return $this->errorNo;
     }
 

--- a/lib/ChargeBee/Request.php
+++ b/lib/ChargeBee/Request.php
@@ -31,7 +31,7 @@ class ChargeBee_Request
 			throw new Exception("ChargeBee api environment is not set. Set your site & api key in ChargeBee_Environment::configure('your_site', 'your_api_key')");
 		}
 		$ser_params = ChargeBee_Util::serialize($params);
-		$response = ChargeBee_Curl::doRequest($method, $url, $env, $ser_params, $headers);
+		$response = ChargeBee_Guzzle::doRequest($method, $url, $env, $ser_params, $headers);
 		if(is_array($response) && array_key_exists("list", $response))
 		{
 			return new ChargeBee_ListResult($response['list'], isset($response['next_offset'])?$response['next_offset']:null);


### PR DESCRIPTION
The PHP cURL extension [causes intermittent issues when running on Google App Engine](https://code.google.com/p/googleappengine/issues/detail?id=12451).  Guzzle provides an abstraction layer for HTTP requests, which allows you to change the underlying service without rewriting application code, and is [the recommended way to issue HTTP requests when using PHP on GAE](https://cloud.google.com/appengine/docs/php/issue-requests#issuing_an_http_request).

Guzzle will continue to use cURL if the extension is enabled, and fallback to stream handlers.
