### PR TITLE
Update ChargeBee_Model to support various return formats

### DIFF
--- a/lib/ChargeBee/Model.php
+++ b/lib/ChargeBee/Model.php
@@ -159,6 +159,11 @@ class ChargeBee_Model
 		return $this;
 	}	
 			
+	public function __toString()
+	{
+		return $this->__toJSON();
+	}
+	
 	public function __toJSON()
 	{
 		return json_encode($this->__toArray());

--- a/lib/ChargeBee/Model.php
+++ b/lib/ChargeBee/Model.php
@@ -166,7 +166,11 @@ class ChargeBee_Model
 	
 	public function __toJSON()
 	{
-		return json_encode($this->__toArray());
+		if (defined('JSON_PRETTY_PRINT')) {
+			return json_encode($this->__toArray(), JSON_PRETTY_PRINT);
+		} else {
+			return json_encode($this->__toArray());
+		}
 	}
 	
 	public function __toArray()

--- a/lib/ChargeBee/Model.php
+++ b/lib/ChargeBee/Model.php
@@ -159,6 +159,11 @@ class ChargeBee_Model
 		return $this;
 	}	
 			
+	public function __toJSON()
+	{
+		return json_encode($this->__toArray());
+	}
+	
 	public function __toArray()
 	{
 		return $this->_values;

--- a/lib/ChargeBee/Model.php
+++ b/lib/ChargeBee/Model.php
@@ -159,6 +159,11 @@ class ChargeBee_Model
 		return $this;
 	}	
 			
+	public function __toArray()
+	{
+		return $this->_values;
+	}
+	
 }
 
 ?>


### PR DESCRIPTION
Using a ChargeBee object as string will return errors since it doesn't support it at the moment. By utilizing PHP's magic method: __toString, it will try to convert it to string using this method. Also added __toArray and __toJSON standard methods to make room for further customization to return.
