### PR TITLE
Fix crash when trying to access an attribute that was not returned by the server but is valid

### DIFF
--- a/lib/ChargeBee/Model.php
+++ b/lib/ChargeBee/Model.php
@@ -62,7 +62,7 @@ class ChargeBee_Model
 		{
 			return $this->_data[$k];
 		} 
-		else if(in_array($k, $this->allowed))
+		else if(in_array(ChargeBee_Util::toUnderscoreFromCamelCase($k), $this->allowed))
 		{
 			return null;
 		}
@@ -82,7 +82,7 @@ class ChargeBee_Model
 		{
 			return $this->_dependantTypes[$k];
 		} 
-		else if(in_array($k, $this->allowed))
+		else if(in_array(ChargeBee_Util::toUnderscoreFromCamelCase($k), $this->allowed))
 		{
 			return null;
 		}


### PR DESCRIPTION
If you are enumerating the line items in an invoice and an item is an `adhoc` type, trying to access the `entityId` attribute crashes rather than returning `null`.

As per the docs: 
> entityId - The identifier of the modelled entity this lineitem is based on. **Will be null for 'adhoc' entity type.**

When I try to access this item, I get:
> Unknown property entityId in ChargeBee_InvoiceLineItem

Based on the documentation, I'd expect to get it returned as "`null`", rather than throwing that exception.  With that said, I dug into your API code and modified `ChargeBee_Model::__get` to dump `$this->_data` and `$this->allowed`.  I then see this:

```
    $this->_data = Array
    (
        [id] => li_1sjs9b5Q3GCSbgmIu
        [dateFrom] => 1479793914
        [dateTo] => 1479793914
        [unitAmount] => 1642
        [quantity] => 1
        [isTaxed] => 
        [taxAmount] => 0
        [object] => line_item
        [amount] => 1642
        [description] => Shipping - UPS - UPS 3 Day Select®
        [entityType] => adhoc
        [discountAmount] => 0
        [itemLevelDiscountAmount] => 0
    )

    $this->allowed = Array
    (
        [0] => id
        [1] => date_from
        [2] => date_to
        [3] => unit_amount
        [4] => quantity
        [5] => is_taxed
        [6] => tax_amount
        [7] => tax_rate
        [8] => amount
        [9] => discount_amount
        [10] => item_level_discount_amount
        [11] => description
        [12] => entity_type
        [13] => entity_id
    )
```

The issue here is that the check for the value (and `ChargeBee_Model::$_data`) uses camel case while `ChargeBee_Model::$allowed` uses underscores.  I honestly don't understand why you implemented the conversion, but since you did, you have to do the conversion when checking `$allowed`.  I'd also surmise that the server should be returning a null `entity_id`, but that is a separate issue.

This pull request fixes the allowed check to check based on underscores instead of camel case so if you access an attribute that is allowed, but `null`, it does not crash.
