### PR TITLE
Adding universal headers to allow headers to be sent every request

### DIFF
--- a/lib/ChargeBee/Environment.php
+++ b/lib/ChargeBee/Environment.php
@@ -5,8 +5,9 @@ class ChargeBee_Environment {
     private $apiKey;
     private $site;
     private $apiEndPoint;
-    
+
     private static $default_env;
+    private static $universal_headers;
     public static $scheme = "https";
     public static $chargebeeDomain;
 
@@ -14,9 +15,10 @@ class ChargeBee_Environment {
     public static  $timeout=100;
     const API_VERSION = "v2";
     
-    function __construct($site, $apiKey) {
+    function __construct($site, $apiKey, $universalHeaders = array()) {
         $this->site = $site;
         $this->apiKey = $apiKey;
+        ChargeBee_Environment::$universal_headers = $universalHeaders;
         if (ChargeBee_Environment::$chargebeeDomain == null) {
             $this->apiEndPoint = "https://$site.chargebee.com/api/" . ChargeBee_Environment::API_VERSION;
         } else {
@@ -44,6 +46,10 @@ class ChargeBee_Environment {
     
     public static function defaultEnv() {
         return ChargeBee_Environment::$default_env;
+    }
+
+    public static function universalHeaders() {
+        return ChargeBee_Environment::$universal_headers;
     }
 
     public function apiUrl($url) {

--- a/lib/ChargeBee/Request.php
+++ b/lib/ChargeBee/Request.php
@@ -31,7 +31,7 @@ class ChargeBee_Request
 			throw new Exception("ChargeBee api environment is not set. Set your site & api key in ChargeBee_Environment::configure('your_site', 'your_api_key')");
 		}
 		$ser_params = ChargeBee_Util::serialize($params);
-		$response = ChargeBee_Curl::doRequest($method, $url, $env, $ser_params, $headers);
+		$response = ChargeBee_Curl::doRequest($method, $url, $env, $ser_params, array_merge(ChargeBee_Environment::universalHeaders(), $headers));
 		if(is_array($response) && array_key_exists("list", $response))
 		{
 			return new ChargeBee_ListResult($response['list'], isset($response['next_offset'])?$response['next_offset']:null);


### PR DESCRIPTION
Sometimes you want to be able to send specific headers with every ChargeBee request.  This allows you to define those in ChargeBee::Environment::configure().