### PR TITLE
fixed ArrayAccess

### DIFF
--- a/lib/ChargeBee/ListResult.php
+++ b/lib/ChargeBee/ListResult.php
@@ -55,7 +55,7 @@ class ChargeBee_ListResult implements Countable, ArrayAccess, Iterator
 
   public function offsetGet($k)
   {
-    return isset($this->list[$k]) ? $this->list[$k] : null;
+    return isset($this->_items[$k]) ? $this->_items[$k] : null;
   }
 
   //Implementation for Iterator functions


### PR DESCRIPTION
ListResult ArrayAccess fixed. Array index accessing was accessing wrong variable `list`. Corrected that to `_items`.