### PR TITLE
Made ListResult->$_index initialize, to be compatible with php8

### DIFF
--- a/lib/ChargeBee/ListResult.php
+++ b/lib/ChargeBee/ListResult.php
@@ -14,7 +14,7 @@ class ListResult implements Countable, ArrayAccess, Iterator
 
     protected $_items;
 
-    private $_index;
+    private $_index = 0;
 
     public function __construct($response, $nextOffset)
     {


### PR DESCRIPTION
Currently, we use chargebeephp with our php7.4 project without hazzle, however, we now have problems that private $_index gets initialized to null in php 0.
We therefore have to fix it by utilizing the rewind command, but this is not quite logical/readable, and would therefore prefer to simply have it initialized from the get go.