### PR TITLE
Add guzzle client as class member

### DIFF
--- a/lib/ChargeBee/Guzzle.php
+++ b/lib/ChargeBee/Guzzle.php
@@ -15,6 +15,8 @@ use GuzzleHttp\Exception\RequestException;
 
 class Guzzle
 {
+    private static $client;
+
     public static function utf8($value) {
         if (is_string($value))
             return utf8_encode($value);
@@ -28,8 +30,19 @@ class Guzzle
         return $respJson;
     }
 
+    private static function getClient() {
+        if(is_null(self::$client)) {
+            self::$client = new Client();
+        }
+        return self::$client;
+    }
+
+    public static function setClient($client) {
+        self::$client = $client;
+    }
+
     public static function request($meth, $url, $env, $params, $headers) {
-        $client = new Client();
+        $client = self::getClient();
 
         $opts = array(
             'connect_timeout' => Environment::$connectTimeoutInSecs,


### PR DESCRIPTION
We are using our charge app behind a proxy manager and need to set proxy settings for guzzle client. Moved client instance from `ChargeBee\ChargeBee\Guzzle::request` to a new class member as `$client` and added public setter / private getter. If a custom client is not set `getClient` initializing a new `Guzzle\Client`


Example usage will be like:

```php
\ChargeBee\ChargeBee\Guzzle::setClient(new GuzzleHttp\Client([
    'proxy' => [
        'http'  => 'http://localhost:8125', // Use this proxy with "http"
        'https' => 'http://localhost:9124', // Use this proxy with "https"
    ]
]));
```