### PR TITLE
Fix Exception class import

### DIFF
--- a/lib/ChargeBee/Models/Event.php
+++ b/lib/ChargeBee/Models/Event.php
@@ -2,6 +2,7 @@
 
 namespace ChargeBee\ChargeBee\Models;
 
+use Exception;
 use ChargeBee\ChargeBee\Model;
 use ChargeBee\ChargeBee\Request;
 use ChargeBee\ChargeBee\Util;


### PR DESCRIPTION
### Description

Exception does not throw with invalid webhook body

### Additional Information

`Error: Class &quot;ChargeBee\ChargeBee\Models\Exception&quot; not found in file /var/www/app/vendor/chargebee/chargebee-php/lib/ChargeBee/Models/Event.php on line 35`
