### PR TITLE
Fix: Change the type of children_ids in hierarchy to array.

### DIFF
--- a/src/Resources/Hierarchy/Hierarchy.php
+++ b/src/Resources/Hierarchy/Hierarchy.php
@@ -29,9 +29,9 @@ class Hierarchy  {
     
     /**
     *
-    * @var ?string $children_ids
+    * @var ?array $children_ids
     */
-    public ?string $children_ids;
+    public ?array $children_ids;
     
     /**
     * @var array<string> $knownFields
@@ -49,7 +49,7 @@ class Hierarchy  {
         ?string $parent_id,
         string $payment_owner_id,
         string $invoice_owner_id,
-        ?string $children_ids,
+        ?array $children_ids,
     )
     { 
         $this->customer_id = $customer_id;


### PR DESCRIPTION
### Description

We're getting an error when trying to retrieve hierarchy from the customer

`Chargebee\Resources\Hierarchy\Hierarchy::__construct(): Argument https://github.com/chargebee/chargebee-php/pull/5 ($children_ids) must be of type ?string, array given, called in /var/www/vendor/chargebee/chargebee-php/src/Resources/Hierarchy/Hierarchy.php on line 64`

### Related Issues

https://github.com/chargebee/chargebee-php/issues/73


### Additional Information

Just try retrieving any hierarchy from Customer with the following code:
$chargebeeClient->customer()->hierarchy('customer_id', [ 'hierarchy_operation_type' => 'COMPLETE_HIERARCHY', ]);
