### PR TITLE
Add __isset method to check if the key exists

### DIFF
--- a/src/ValueObjects/SupportsCustomFields.php
+++ b/src/ValueObjects/SupportsCustomFields.php
@@ -17,4 +17,9 @@ class SupportsCustomFields {
         }
         return null;
     }
+
+    public function __isset($key): bool
+    {
+        return array_key_exists($key, $this->_data);
+    }
 }


### PR DESCRIPTION
### Description

Implements `__isset` in `SupportsCustomFields` to check if the key exists in `_data`. Necessary to work with `empty` and `isset` functions.

### Related Issues

Closes #90


