### PR TITLE
fixed the issue with method_exists and json_keys.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+### v4.8.1 (2025-09-03)
+
+### Bug Fixes:
+
+* Fixed an issue where `method_exists` failed on `null` objects, which caused errors when extracting status codes. (Resolves #102)
+* Corrected parameter parsing: action JSON keys use `camelCase`, but the parser did not account for this, leading to incorrect comparisons. (Resolves #97)
+
+### PHPDocs Improvements:
+* Added `@throws` annotations in PHPDocs for all relevant exceptions.
+
+### Dev Improvements:
+* Added unit tests form url for encoder. 
+
 ### v4.8.0 (2025-08-19) 
 * * * 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,13 @@
-### v4.8.1 (2025-09-03)
+### v4.9.0 (2025-09-03)
 
 ### Bug Fixes:
 
 * Fixed an issue where `method_exists` failed on `null` objects, which caused errors when extracting status codes. (Resolves #102)
 * Corrected parameter parsing: action JSON keys use `camelCase`, but the parser did not account for this, leading to incorrect comparisons. (Resolves #97)
 
-### PHPDocs Improvements:
+### Enhancements: 
+* List object classes have been moved to separate files to align with `PSR-4` directory standards. (Resolves #98)
 * Added `@throws` annotations in PHPDocs for all relevant exceptions.
-
-### Dev Improvements:
 * Added unit tests form url for encoder. 
 
 ### v4.8.0 (2025-08-19) 

--- a/composer.json
+++ b/composer.json
@@ -2,10 +2,14 @@
     "name": "chargebee/chargebee-php",
     "type": "library",
     "description": "ChargeBee API client implementation for PHP",
-    "keywords": ["chargebee", "payments", "subscription billing", "recurring billing"],
+    "keywords": [
+        "chargebee",
+        "payments",
+        "subscription billing",
+        "recurring billing"
+    ],
     "license": "MIT",
     "homepage": "https://github.com/chargebee/chargebee-php",
-
     "require": {
         "php": ">=8.1.0",
         "guzzlehttp/guzzle": ">=7",
@@ -19,7 +23,13 @@
             "src/ChargebeeClient.php"
         ]
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests/"
+        }
+    },
     "require-dev": {
-        "phpstan/phpstan": "^2.1"
+        "phpstan/phpstan": "^2.1",
+        "phpunit/phpunit": "^12.3"
     }
 }

--- a/src/Actions/AddonActions.php
+++ b/src/Actions/AddonActions.php
@@ -15,6 +15,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class AddonActions implements AddonActionsInterface
 {
@@ -36,6 +42,13 @@ final class AddonActions implements AddonActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CopyAddonResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function copy(array $params, array $headers = []): CopyAddonResponse
     {
@@ -63,6 +76,13 @@ final class AddonActions implements AddonActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UnarchiveAddonResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function unarchive(string $id, array $headers = []): UnarchiveAddonResponse
     {
@@ -89,6 +109,13 @@ final class AddonActions implements AddonActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveAddonResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveAddonResponse
     {
@@ -164,6 +191,13 @@ final class AddonActions implements AddonActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateAddonResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params, array $headers = []): UpdateAddonResponse
     {
@@ -277,6 +311,13 @@ final class AddonActions implements AddonActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListAddonResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListAddonResponse
     {
@@ -355,6 +396,13 @@ final class AddonActions implements AddonActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateAddonResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateAddonResponse
     {
@@ -383,6 +431,13 @@ final class AddonActions implements AddonActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteAddonResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteAddonResponse
     {

--- a/src/Actions/AddonActions.php
+++ b/src/Actions/AddonActions.php
@@ -16,7 +16,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -43,12 +42,10 @@ final class AddonActions implements AddonActionsInterface
     *   @param array<string, string> $headers
     *   @return CopyAddonResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function copy(array $params, array $headers = []): CopyAddonResponse
     {
@@ -77,12 +74,10 @@ final class AddonActions implements AddonActionsInterface
     *   @param array<string, string> $headers
     *   @return UnarchiveAddonResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function unarchive(string $id, array $headers = []): UnarchiveAddonResponse
     {
@@ -110,12 +105,10 @@ final class AddonActions implements AddonActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveAddonResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveAddonResponse
     {
@@ -192,12 +185,10 @@ final class AddonActions implements AddonActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateAddonResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params, array $headers = []): UpdateAddonResponse
     {
@@ -312,12 +303,10 @@ final class AddonActions implements AddonActionsInterface
     *   @param array<string, string> $headers
     *   @return ListAddonResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListAddonResponse
     {
@@ -397,12 +386,10 @@ final class AddonActions implements AddonActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateAddonResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateAddonResponse
     {
@@ -432,12 +419,10 @@ final class AddonActions implements AddonActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteAddonResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteAddonResponse
     {

--- a/src/Actions/AddressActions.php
+++ b/src/Actions/AddressActions.php
@@ -9,6 +9,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class AddressActions implements AddressActionsInterface
 {
@@ -28,6 +34,13 @@ final class AddressActions implements AddressActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return RetrieveAddressResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(array $params, array $headers = []): RetrieveAddressResponse
     {
@@ -71,6 +84,13 @@ final class AddressActions implements AddressActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return UpdateAddressResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function update(array $params, array $headers = []): UpdateAddressResponse
     {

--- a/src/Actions/AddressActions.php
+++ b/src/Actions/AddressActions.php
@@ -10,7 +10,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -35,12 +34,10 @@ final class AddressActions implements AddressActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveAddressResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(array $params, array $headers = []): RetrieveAddressResponse
     {
@@ -85,12 +82,10 @@ final class AddressActions implements AddressActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateAddressResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function update(array $params, array $headers = []): UpdateAddressResponse
     {

--- a/src/Actions/AttachedItemActions.php
+++ b/src/Actions/AttachedItemActions.php
@@ -13,6 +13,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class AttachedItemActions implements AttachedItemActionsInterface
 {
@@ -31,6 +37,13 @@ final class AttachedItemActions implements AttachedItemActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveAttachedItemResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $params, array $headers = []): RetrieveAttachedItemResponse
     {
@@ -65,6 +78,13 @@ final class AttachedItemActions implements AttachedItemActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateAttachedItemResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params, array $headers = []): UpdateAttachedItemResponse
     {
@@ -133,6 +153,13 @@ final class AttachedItemActions implements AttachedItemActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ListAttachedItemResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(string $id, array $params = [], array $headers = []): ListAttachedItemResponse
     {
@@ -168,6 +195,13 @@ final class AttachedItemActions implements AttachedItemActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CreateAttachedItemResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(string $id, array $params, array $headers = []): CreateAttachedItemResponse
     {
@@ -197,6 +231,13 @@ final class AttachedItemActions implements AttachedItemActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteAttachedItemResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $params, array $headers = []): DeleteAttachedItemResponse
     {

--- a/src/Actions/AttachedItemActions.php
+++ b/src/Actions/AttachedItemActions.php
@@ -14,7 +14,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -38,12 +37,10 @@ final class AttachedItemActions implements AttachedItemActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveAttachedItemResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $params, array $headers = []): RetrieveAttachedItemResponse
     {
@@ -79,12 +76,10 @@ final class AttachedItemActions implements AttachedItemActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateAttachedItemResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params, array $headers = []): UpdateAttachedItemResponse
     {
@@ -154,12 +149,10 @@ final class AttachedItemActions implements AttachedItemActionsInterface
     *   @param array<string, string> $headers
     *   @return ListAttachedItemResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(string $id, array $params = [], array $headers = []): ListAttachedItemResponse
     {
@@ -196,12 +189,10 @@ final class AttachedItemActions implements AttachedItemActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateAttachedItemResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(string $id, array $params, array $headers = []): CreateAttachedItemResponse
     {
@@ -232,12 +223,10 @@ final class AttachedItemActions implements AttachedItemActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteAttachedItemResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $params, array $headers = []): DeleteAttachedItemResponse
     {

--- a/src/Actions/BusinessEntityActions.php
+++ b/src/Actions/BusinessEntityActions.php
@@ -10,6 +10,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class BusinessEntityActions implements BusinessEntityActionsInterface
 {
@@ -48,6 +54,13 @@ final class BusinessEntityActions implements BusinessEntityActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return GetTransfersBusinessEntityResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function getTransfers(array $params = [], array $headers = []): GetTransfersBusinessEntityResponse
     {
@@ -80,6 +93,13 @@ final class BusinessEntityActions implements BusinessEntityActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateTransfersBusinessEntityResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createTransfers(array $params, array $headers = []): CreateTransfersBusinessEntityResponse
     {

--- a/src/Actions/BusinessEntityActions.php
+++ b/src/Actions/BusinessEntityActions.php
@@ -11,7 +11,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -55,12 +54,10 @@ final class BusinessEntityActions implements BusinessEntityActionsInterface
     *   @param array<string, string> $headers
     *   @return GetTransfersBusinessEntityResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function getTransfers(array $params = [], array $headers = []): GetTransfersBusinessEntityResponse
     {
@@ -94,12 +91,10 @@ final class BusinessEntityActions implements BusinessEntityActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateTransfersBusinessEntityResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createTransfers(array $params, array $headers = []): CreateTransfersBusinessEntityResponse
     {

--- a/src/Actions/CardActions.php
+++ b/src/Actions/CardActions.php
@@ -12,6 +12,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class CardActions implements CardActionsInterface
 {
@@ -30,6 +36,13 @@ final class CardActions implements CardActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CopyCardForCustomerCardResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function copyCardForCustomer(string $id, array $params, array $headers = []): CopyCardForCustomerCardResponse
     {
@@ -57,6 +70,13 @@ final class CardActions implements CardActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveCardResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveCardResponse
     {
@@ -85,6 +105,13 @@ final class CardActions implements CardActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return SwitchGatewayForCustomerCardResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function switchGatewayForCustomer(string $id, array $params, array $headers = []): SwitchGatewayForCustomerCardResponse
     {
@@ -112,6 +139,13 @@ final class CardActions implements CardActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteCardForCustomerCardResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function deleteCardForCustomer(string $id, array $headers = []): DeleteCardForCustomerCardResponse
     {
@@ -160,6 +194,13 @@ final class CardActions implements CardActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateCardForCustomerCardResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function updateCardForCustomer(string $id, array $params, array $headers = []): UpdateCardForCustomerCardResponse
     {

--- a/src/Actions/CardActions.php
+++ b/src/Actions/CardActions.php
@@ -13,7 +13,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -37,12 +36,10 @@ final class CardActions implements CardActionsInterface
     *   @param array<string, string> $headers
     *   @return CopyCardForCustomerCardResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function copyCardForCustomer(string $id, array $params, array $headers = []): CopyCardForCustomerCardResponse
     {
@@ -71,12 +68,10 @@ final class CardActions implements CardActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveCardResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveCardResponse
     {
@@ -106,12 +101,10 @@ final class CardActions implements CardActionsInterface
     *   @param array<string, string> $headers
     *   @return SwitchGatewayForCustomerCardResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function switchGatewayForCustomer(string $id, array $params, array $headers = []): SwitchGatewayForCustomerCardResponse
     {
@@ -140,12 +133,10 @@ final class CardActions implements CardActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteCardForCustomerCardResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function deleteCardForCustomer(string $id, array $headers = []): DeleteCardForCustomerCardResponse
     {
@@ -195,12 +186,10 @@ final class CardActions implements CardActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateCardForCustomerCardResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function updateCardForCustomer(string $id, array $params, array $headers = []): UpdateCardForCustomerCardResponse
     {

--- a/src/Actions/CommentActions.php
+++ b/src/Actions/CommentActions.php
@@ -13,7 +13,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -35,12 +34,10 @@ final class CommentActions implements CommentActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteCommentResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteCommentResponse
     {
@@ -68,12 +65,10 @@ final class CommentActions implements CommentActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveCommentResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveCommentResponse
     {
@@ -115,12 +110,10 @@ final class CommentActions implements CommentActionsInterface
     *   @param array<string, string> $headers
     *   @return ListCommentResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListCommentResponse
     {
@@ -153,12 +146,10 @@ final class CommentActions implements CommentActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateCommentResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateCommentResponse
     {

--- a/src/Actions/CommentActions.php
+++ b/src/Actions/CommentActions.php
@@ -12,6 +12,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class CommentActions implements CommentActionsInterface
 {
@@ -28,6 +34,13 @@ final class CommentActions implements CommentActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteCommentResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteCommentResponse
     {
@@ -54,6 +67,13 @@ final class CommentActions implements CommentActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveCommentResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveCommentResponse
     {
@@ -94,6 +114,13 @@ final class CommentActions implements CommentActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListCommentResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListCommentResponse
     {
@@ -125,6 +152,13 @@ final class CommentActions implements CommentActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateCommentResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateCommentResponse
     {

--- a/src/Actions/ConfigurationActions.php
+++ b/src/Actions/ConfigurationActions.php
@@ -8,6 +8,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class ConfigurationActions implements ConfigurationActionsInterface
 {
@@ -24,6 +30,13 @@ final class ConfigurationActions implements ConfigurationActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListConfigurationResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $headers = []): ListConfigurationResponse
     {

--- a/src/Actions/ConfigurationActions.php
+++ b/src/Actions/ConfigurationActions.php
@@ -9,7 +9,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -31,12 +30,10 @@ final class ConfigurationActions implements ConfigurationActionsInterface
     *   @param array<string, string> $headers
     *   @return ListConfigurationResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $headers = []): ListConfigurationResponse
     {

--- a/src/Actions/Contracts/AddonActionsInterface.php
+++ b/src/Actions/Contracts/AddonActionsInterface.php
@@ -9,7 +9,6 @@ use Chargebee\Responses\AddonResponse\UnarchiveAddonResponse;
 use Chargebee\Responses\AddonResponse\CreateAddonResponse;
 use Chargebee\Responses\AddonResponse\DeleteAddonResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -30,12 +29,10 @@ Interface AddonActionsInterface
     *   @param array<string, string> $headers
     *   @return CopyAddonResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function copy(array $params, array $headers = []): CopyAddonResponse;
 
@@ -46,12 +43,10 @@ Interface AddonActionsInterface
     *   @param array<string, string> $headers
     *   @return UnarchiveAddonResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function unarchive(string $id, array $headers = []): UnarchiveAddonResponse;
 
@@ -62,12 +57,10 @@ Interface AddonActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveAddonResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveAddonResponse;
 
@@ -128,12 +121,10 @@ Interface AddonActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateAddonResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params, array $headers = []): UpdateAddonResponse;
 
@@ -229,12 +220,10 @@ Interface AddonActionsInterface
     *   @param array<string, string> $headers
     *   @return ListAddonResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListAddonResponse;
 
@@ -297,12 +286,10 @@ Interface AddonActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateAddonResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateAddonResponse;
 
@@ -313,12 +300,10 @@ Interface AddonActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteAddonResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteAddonResponse;
 

--- a/src/Actions/Contracts/AddonActionsInterface.php
+++ b/src/Actions/Contracts/AddonActionsInterface.php
@@ -8,6 +8,12 @@ use Chargebee\Responses\AddonResponse\UpdateAddonResponse;
 use Chargebee\Responses\AddonResponse\UnarchiveAddonResponse;
 use Chargebee\Responses\AddonResponse\CreateAddonResponse;
 use Chargebee\Responses\AddonResponse\DeleteAddonResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface AddonActionsInterface
 {
@@ -23,6 +29,13 @@ Interface AddonActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CopyAddonResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function copy(array $params, array $headers = []): CopyAddonResponse;
 
@@ -32,6 +45,13 @@ Interface AddonActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UnarchiveAddonResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function unarchive(string $id, array $headers = []): UnarchiveAddonResponse;
 
@@ -41,6 +61,13 @@ Interface AddonActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveAddonResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveAddonResponse;
 
@@ -100,6 +127,13 @@ Interface AddonActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateAddonResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params, array $headers = []): UpdateAddonResponse;
 
@@ -194,6 +228,13 @@ Interface AddonActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListAddonResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListAddonResponse;
 
@@ -255,6 +296,13 @@ Interface AddonActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateAddonResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateAddonResponse;
 
@@ -264,6 +312,13 @@ Interface AddonActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteAddonResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteAddonResponse;
 

--- a/src/Actions/Contracts/AddressActionsInterface.php
+++ b/src/Actions/Contracts/AddressActionsInterface.php
@@ -3,6 +3,12 @@ namespace Chargebee\Actions\Contracts;
     
 use Chargebee\Responses\AddressResponse\UpdateAddressResponse;
 use Chargebee\Responses\AddressResponse\RetrieveAddressResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface AddressActionsInterface
 {
@@ -16,6 +22,13 @@ Interface AddressActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return RetrieveAddressResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(array $params, array $headers = []): RetrieveAddressResponse;
 
@@ -42,6 +55,13 @@ Interface AddressActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return UpdateAddressResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function update(array $params, array $headers = []): UpdateAddressResponse;
 

--- a/src/Actions/Contracts/AddressActionsInterface.php
+++ b/src/Actions/Contracts/AddressActionsInterface.php
@@ -4,7 +4,6 @@ namespace Chargebee\Actions\Contracts;
 use Chargebee\Responses\AddressResponse\UpdateAddressResponse;
 use Chargebee\Responses\AddressResponse\RetrieveAddressResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -23,12 +22,10 @@ Interface AddressActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveAddressResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(array $params, array $headers = []): RetrieveAddressResponse;
 
@@ -56,12 +53,10 @@ Interface AddressActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateAddressResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function update(array $params, array $headers = []): UpdateAddressResponse;
 

--- a/src/Actions/Contracts/AttachedItemActionsInterface.php
+++ b/src/Actions/Contracts/AttachedItemActionsInterface.php
@@ -7,7 +7,6 @@ use Chargebee\Responses\AttachedItemResponse\DeleteAttachedItemResponse;
 use Chargebee\Responses\AttachedItemResponse\CreateAttachedItemResponse;
 use Chargebee\Responses\AttachedItemResponse\UpdateAttachedItemResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -25,12 +24,10 @@ Interface AttachedItemActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveAttachedItemResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $params, array $headers = []): RetrieveAttachedItemResponse;
 
@@ -49,12 +46,10 @@ Interface AttachedItemActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateAttachedItemResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params, array $headers = []): UpdateAttachedItemResponse;
 
@@ -106,12 +101,10 @@ Interface AttachedItemActionsInterface
     *   @param array<string, string> $headers
     *   @return ListAttachedItemResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(string $id, array $params = [], array $headers = []): ListAttachedItemResponse;
 
@@ -131,12 +124,10 @@ Interface AttachedItemActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateAttachedItemResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(string $id, array $params, array $headers = []): CreateAttachedItemResponse;
 
@@ -149,12 +140,10 @@ Interface AttachedItemActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteAttachedItemResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $params, array $headers = []): DeleteAttachedItemResponse;
 

--- a/src/Actions/Contracts/AttachedItemActionsInterface.php
+++ b/src/Actions/Contracts/AttachedItemActionsInterface.php
@@ -6,6 +6,12 @@ use Chargebee\Responses\AttachedItemResponse\RetrieveAttachedItemResponse;
 use Chargebee\Responses\AttachedItemResponse\DeleteAttachedItemResponse;
 use Chargebee\Responses\AttachedItemResponse\CreateAttachedItemResponse;
 use Chargebee\Responses\AttachedItemResponse\UpdateAttachedItemResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface AttachedItemActionsInterface
 {
@@ -18,6 +24,13 @@ Interface AttachedItemActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveAttachedItemResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $params, array $headers = []): RetrieveAttachedItemResponse;
 
@@ -35,6 +48,13 @@ Interface AttachedItemActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateAttachedItemResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params, array $headers = []): UpdateAttachedItemResponse;
 
@@ -85,6 +105,13 @@ Interface AttachedItemActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ListAttachedItemResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(string $id, array $params = [], array $headers = []): ListAttachedItemResponse;
 
@@ -103,6 +130,13 @@ Interface AttachedItemActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CreateAttachedItemResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(string $id, array $params, array $headers = []): CreateAttachedItemResponse;
 
@@ -114,6 +148,13 @@ Interface AttachedItemActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteAttachedItemResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $params, array $headers = []): DeleteAttachedItemResponse;
 

--- a/src/Actions/Contracts/BusinessEntityActionsInterface.php
+++ b/src/Actions/Contracts/BusinessEntityActionsInterface.php
@@ -3,6 +3,12 @@ namespace Chargebee\Actions\Contracts;
     
 use Chargebee\Responses\BusinessEntityResponse\GetTransfersBusinessEntityResponse;
 use Chargebee\Responses\BusinessEntityResponse\CreateTransfersBusinessEntityResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface BusinessEntityActionsInterface
 {
@@ -35,6 +41,13 @@ Interface BusinessEntityActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return GetTransfersBusinessEntityResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function getTransfers(array $params = [], array $headers = []): GetTransfersBusinessEntityResponse;
 
@@ -50,6 +63,13 @@ Interface BusinessEntityActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateTransfersBusinessEntityResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createTransfers(array $params, array $headers = []): CreateTransfersBusinessEntityResponse;
 

--- a/src/Actions/Contracts/BusinessEntityActionsInterface.php
+++ b/src/Actions/Contracts/BusinessEntityActionsInterface.php
@@ -4,7 +4,6 @@ namespace Chargebee\Actions\Contracts;
 use Chargebee\Responses\BusinessEntityResponse\GetTransfersBusinessEntityResponse;
 use Chargebee\Responses\BusinessEntityResponse\CreateTransfersBusinessEntityResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -42,12 +41,10 @@ Interface BusinessEntityActionsInterface
     *   @param array<string, string> $headers
     *   @return GetTransfersBusinessEntityResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function getTransfers(array $params = [], array $headers = []): GetTransfersBusinessEntityResponse;
 
@@ -64,12 +61,10 @@ Interface BusinessEntityActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateTransfersBusinessEntityResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createTransfers(array $params, array $headers = []): CreateTransfersBusinessEntityResponse;
 

--- a/src/Actions/Contracts/CardActionsInterface.php
+++ b/src/Actions/Contracts/CardActionsInterface.php
@@ -7,7 +7,6 @@ use Chargebee\Responses\CardResponse\SwitchGatewayForCustomerCardResponse;
 use Chargebee\Responses\CardResponse\DeleteCardForCustomerCardResponse;
 use Chargebee\Responses\CardResponse\UpdateCardForCustomerCardResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -25,12 +24,10 @@ Interface CardActionsInterface
     *   @param array<string, string> $headers
     *   @return CopyCardForCustomerCardResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function copyCardForCustomer(string $id, array $params, array $headers = []): CopyCardForCustomerCardResponse;
 
@@ -41,12 +38,10 @@ Interface CardActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveCardResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveCardResponse;
 
@@ -60,12 +55,10 @@ Interface CardActionsInterface
     *   @param array<string, string> $headers
     *   @return SwitchGatewayForCustomerCardResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function switchGatewayForCustomer(string $id, array $params, array $headers = []): SwitchGatewayForCustomerCardResponse;
 
@@ -76,12 +69,10 @@ Interface CardActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteCardForCustomerCardResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function deleteCardForCustomer(string $id, array $headers = []): DeleteCardForCustomerCardResponse;
 
@@ -114,12 +105,10 @@ Interface CardActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateCardForCustomerCardResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function updateCardForCustomer(string $id, array $params, array $headers = []): UpdateCardForCustomerCardResponse;
 

--- a/src/Actions/Contracts/CardActionsInterface.php
+++ b/src/Actions/Contracts/CardActionsInterface.php
@@ -6,6 +6,12 @@ use Chargebee\Responses\CardResponse\RetrieveCardResponse;
 use Chargebee\Responses\CardResponse\SwitchGatewayForCustomerCardResponse;
 use Chargebee\Responses\CardResponse\DeleteCardForCustomerCardResponse;
 use Chargebee\Responses\CardResponse\UpdateCardForCustomerCardResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface CardActionsInterface
 {
@@ -18,6 +24,13 @@ Interface CardActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CopyCardForCustomerCardResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function copyCardForCustomer(string $id, array $params, array $headers = []): CopyCardForCustomerCardResponse;
 
@@ -27,6 +40,13 @@ Interface CardActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveCardResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveCardResponse;
 
@@ -39,6 +59,13 @@ Interface CardActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return SwitchGatewayForCustomerCardResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function switchGatewayForCustomer(string $id, array $params, array $headers = []): SwitchGatewayForCustomerCardResponse;
 
@@ -48,6 +75,13 @@ Interface CardActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteCardForCustomerCardResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function deleteCardForCustomer(string $id, array $headers = []): DeleteCardForCustomerCardResponse;
 
@@ -79,6 +113,13 @@ Interface CardActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateCardForCustomerCardResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function updateCardForCustomer(string $id, array $params, array $headers = []): UpdateCardForCustomerCardResponse;
 

--- a/src/Actions/Contracts/CommentActionsInterface.php
+++ b/src/Actions/Contracts/CommentActionsInterface.php
@@ -6,7 +6,6 @@ use Chargebee\Responses\CommentResponse\RetrieveCommentResponse;
 use Chargebee\Responses\CommentResponse\DeleteCommentResponse;
 use Chargebee\Responses\CommentResponse\CreateCommentResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -22,12 +21,10 @@ Interface CommentActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteCommentResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteCommentResponse;
 
@@ -38,12 +35,10 @@ Interface CommentActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveCommentResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveCommentResponse;
 
@@ -69,12 +64,10 @@ Interface CommentActionsInterface
     *   @param array<string, string> $headers
     *   @return ListCommentResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListCommentResponse;
 
@@ -90,12 +83,10 @@ Interface CommentActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateCommentResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateCommentResponse;
 

--- a/src/Actions/Contracts/CommentActionsInterface.php
+++ b/src/Actions/Contracts/CommentActionsInterface.php
@@ -5,6 +5,12 @@ use Chargebee\Responses\CommentResponse\ListCommentResponse;
 use Chargebee\Responses\CommentResponse\RetrieveCommentResponse;
 use Chargebee\Responses\CommentResponse\DeleteCommentResponse;
 use Chargebee\Responses\CommentResponse\CreateCommentResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface CommentActionsInterface
 {
@@ -15,6 +21,13 @@ Interface CommentActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteCommentResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteCommentResponse;
 
@@ -24,6 +37,13 @@ Interface CommentActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveCommentResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveCommentResponse;
 
@@ -48,6 +68,13 @@ Interface CommentActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListCommentResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListCommentResponse;
 
@@ -62,6 +89,13 @@ Interface CommentActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateCommentResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateCommentResponse;
 

--- a/src/Actions/Contracts/ConfigurationActionsInterface.php
+++ b/src/Actions/Contracts/ConfigurationActionsInterface.php
@@ -2,6 +2,12 @@
 namespace Chargebee\Actions\Contracts;
     
 use Chargebee\Responses\ConfigurationResponse\ListConfigurationResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface ConfigurationActionsInterface
 {
@@ -12,6 +18,13 @@ Interface ConfigurationActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListConfigurationResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $headers = []): ListConfigurationResponse;
 

--- a/src/Actions/Contracts/ConfigurationActionsInterface.php
+++ b/src/Actions/Contracts/ConfigurationActionsInterface.php
@@ -3,7 +3,6 @@ namespace Chargebee\Actions\Contracts;
     
 use Chargebee\Responses\ConfigurationResponse\ListConfigurationResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -19,12 +18,10 @@ Interface ConfigurationActionsInterface
     *   @param array<string, string> $headers
     *   @return ListConfigurationResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $headers = []): ListConfigurationResponse;
 

--- a/src/Actions/Contracts/CouponActionsInterface.php
+++ b/src/Actions/Contracts/CouponActionsInterface.php
@@ -10,6 +10,12 @@ use Chargebee\Responses\CouponResponse\CreateForItemsCouponResponse;
 use Chargebee\Responses\CouponResponse\UnarchiveCouponResponse;
 use Chargebee\Responses\CouponResponse\ListCouponResponse;
 use Chargebee\Responses\CouponResponse\CreateCouponResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface CouponActionsInterface
 {
@@ -84,6 +90,13 @@ Interface CouponActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListCouponResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListCouponResponse;
 
@@ -117,6 +130,13 @@ Interface CouponActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateCouponResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateCouponResponse;
 
@@ -161,6 +181,13 @@ Interface CouponActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateForItemsCouponResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function updateForItems(string $id, array $params, array $headers = []): UpdateForItemsCouponResponse;
 
@@ -170,6 +197,13 @@ Interface CouponActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UnarchiveCouponResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function unarchive(string $id, array $headers = []): UnarchiveCouponResponse;
 
@@ -179,6 +213,13 @@ Interface CouponActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteCouponResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteCouponResponse;
 
@@ -193,6 +234,13 @@ Interface CouponActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CopyCouponResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function copy(array $params, array $headers = []): CopyCouponResponse;
 
@@ -202,6 +250,13 @@ Interface CouponActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveCouponResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveCouponResponse;
 
@@ -233,6 +288,13 @@ Interface CouponActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateCouponResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdateCouponResponse;
 
@@ -279,6 +341,13 @@ Interface CouponActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateForItemsCouponResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createForItems(array $params, array $headers = []): CreateForItemsCouponResponse;
 

--- a/src/Actions/Contracts/CouponActionsInterface.php
+++ b/src/Actions/Contracts/CouponActionsInterface.php
@@ -11,7 +11,6 @@ use Chargebee\Responses\CouponResponse\UnarchiveCouponResponse;
 use Chargebee\Responses\CouponResponse\ListCouponResponse;
 use Chargebee\Responses\CouponResponse\CreateCouponResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -91,12 +90,10 @@ Interface CouponActionsInterface
     *   @param array<string, string> $headers
     *   @return ListCouponResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListCouponResponse;
 
@@ -131,12 +128,10 @@ Interface CouponActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateCouponResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateCouponResponse;
 
@@ -182,12 +177,10 @@ Interface CouponActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateForItemsCouponResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function updateForItems(string $id, array $params, array $headers = []): UpdateForItemsCouponResponse;
 
@@ -198,12 +191,10 @@ Interface CouponActionsInterface
     *   @param array<string, string> $headers
     *   @return UnarchiveCouponResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function unarchive(string $id, array $headers = []): UnarchiveCouponResponse;
 
@@ -214,12 +205,10 @@ Interface CouponActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteCouponResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteCouponResponse;
 
@@ -235,12 +224,10 @@ Interface CouponActionsInterface
     *   @param array<string, string> $headers
     *   @return CopyCouponResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function copy(array $params, array $headers = []): CopyCouponResponse;
 
@@ -251,12 +238,10 @@ Interface CouponActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveCouponResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveCouponResponse;
 
@@ -289,12 +274,10 @@ Interface CouponActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateCouponResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdateCouponResponse;
 
@@ -342,12 +325,10 @@ Interface CouponActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateForItemsCouponResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createForItems(array $params, array $headers = []): CreateForItemsCouponResponse;
 

--- a/src/Actions/Contracts/CouponCodeActionsInterface.php
+++ b/src/Actions/Contracts/CouponCodeActionsInterface.php
@@ -5,6 +5,12 @@ use Chargebee\Responses\CouponCodeResponse\ListCouponCodeResponse;
 use Chargebee\Responses\CouponCodeResponse\CreateCouponCodeResponse;
 use Chargebee\Responses\CouponCodeResponse\RetrieveCouponCodeResponse;
 use Chargebee\Responses\CouponCodeResponse\ArchiveCouponCodeResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface CouponCodeActionsInterface
 {
@@ -43,6 +49,13 @@ Interface CouponCodeActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListCouponCodeResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListCouponCodeResponse;
 
@@ -56,6 +69,13 @@ Interface CouponCodeActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateCouponCodeResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateCouponCodeResponse;
 
@@ -65,6 +85,13 @@ Interface CouponCodeActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveCouponCodeResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveCouponCodeResponse;
 
@@ -74,6 +101,13 @@ Interface CouponCodeActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ArchiveCouponCodeResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function archive(string $id, array $headers = []): ArchiveCouponCodeResponse;
 

--- a/src/Actions/Contracts/CouponCodeActionsInterface.php
+++ b/src/Actions/Contracts/CouponCodeActionsInterface.php
@@ -6,7 +6,6 @@ use Chargebee\Responses\CouponCodeResponse\CreateCouponCodeResponse;
 use Chargebee\Responses\CouponCodeResponse\RetrieveCouponCodeResponse;
 use Chargebee\Responses\CouponCodeResponse\ArchiveCouponCodeResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -50,12 +49,10 @@ Interface CouponCodeActionsInterface
     *   @param array<string, string> $headers
     *   @return ListCouponCodeResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListCouponCodeResponse;
 
@@ -70,12 +67,10 @@ Interface CouponCodeActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateCouponCodeResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateCouponCodeResponse;
 
@@ -86,12 +81,10 @@ Interface CouponCodeActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveCouponCodeResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveCouponCodeResponse;
 
@@ -102,12 +95,10 @@ Interface CouponCodeActionsInterface
     *   @param array<string, string> $headers
     *   @return ArchiveCouponCodeResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function archive(string $id, array $headers = []): ArchiveCouponCodeResponse;
 

--- a/src/Actions/Contracts/CouponSetActionsInterface.php
+++ b/src/Actions/Contracts/CouponSetActionsInterface.php
@@ -8,6 +8,12 @@ use Chargebee\Responses\CouponSetResponse\ListCouponSetResponse;
 use Chargebee\Responses\CouponSetResponse\UpdateCouponSetResponse;
 use Chargebee\Responses\CouponSetResponse\DeleteCouponSetResponse;
 use Chargebee\Responses\CouponSetResponse\DeleteUnusedCouponCodesCouponSetResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface CouponSetActionsInterface
 {
@@ -69,6 +75,13 @@ Interface CouponSetActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListCouponSetResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListCouponSetResponse;
 
@@ -83,6 +96,13 @@ Interface CouponSetActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateCouponSetResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateCouponSetResponse;
 
@@ -95,6 +115,13 @@ Interface CouponSetActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateCouponSetResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdateCouponSetResponse;
 
@@ -104,6 +131,13 @@ Interface CouponSetActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveCouponSetResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveCouponSetResponse;
 
@@ -115,6 +149,13 @@ Interface CouponSetActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return AddCouponCodesCouponSetResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function addCouponCodes(string $id, array $params = [], array $headers = []): AddCouponCodesCouponSetResponse;
 
@@ -124,6 +165,13 @@ Interface CouponSetActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteUnusedCouponCodesCouponSetResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function deleteUnusedCouponCodes(string $id, array $headers = []): DeleteUnusedCouponCodesCouponSetResponse;
 
@@ -133,6 +181,13 @@ Interface CouponSetActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteCouponSetResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteCouponSetResponse;
 

--- a/src/Actions/Contracts/CouponSetActionsInterface.php
+++ b/src/Actions/Contracts/CouponSetActionsInterface.php
@@ -9,7 +9,6 @@ use Chargebee\Responses\CouponSetResponse\UpdateCouponSetResponse;
 use Chargebee\Responses\CouponSetResponse\DeleteCouponSetResponse;
 use Chargebee\Responses\CouponSetResponse\DeleteUnusedCouponCodesCouponSetResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -76,12 +75,10 @@ Interface CouponSetActionsInterface
     *   @param array<string, string> $headers
     *   @return ListCouponSetResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListCouponSetResponse;
 
@@ -97,12 +94,10 @@ Interface CouponSetActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateCouponSetResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateCouponSetResponse;
 
@@ -116,12 +111,10 @@ Interface CouponSetActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateCouponSetResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdateCouponSetResponse;
 
@@ -132,12 +125,10 @@ Interface CouponSetActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveCouponSetResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveCouponSetResponse;
 
@@ -150,12 +141,10 @@ Interface CouponSetActionsInterface
     *   @param array<string, string> $headers
     *   @return AddCouponCodesCouponSetResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function addCouponCodes(string $id, array $params = [], array $headers = []): AddCouponCodesCouponSetResponse;
 
@@ -166,12 +155,10 @@ Interface CouponSetActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteUnusedCouponCodesCouponSetResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function deleteUnusedCouponCodes(string $id, array $headers = []): DeleteUnusedCouponCodesCouponSetResponse;
 
@@ -182,12 +169,10 @@ Interface CouponSetActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteCouponSetResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteCouponSetResponse;
 

--- a/src/Actions/Contracts/CreditNoteActionsInterface.php
+++ b/src/Actions/Contracts/CreditNoteActionsInterface.php
@@ -16,7 +16,6 @@ use Chargebee\Responses\CreditNoteResponse\PdfCreditNoteResponse;
 use Chargebee\Responses\CreditNoteResponse\RefundCreditNoteResponse;
 use Chargebee\Responses\CreditNoteResponse\RecordRefundCreditNoteResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -34,12 +33,10 @@ Interface CreditNoteActionsInterface
     *   @param array<string, string> $headers
     *   @return VoidCreditNoteCreditNoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function voidCreditNote(string $id, array $params = [], array $headers = []): VoidCreditNoteCreditNoteResponse;
 
@@ -54,12 +51,10 @@ Interface CreditNoteActionsInterface
     *   @param array<string, string> $headers
     *   @return RefundCreditNoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function refund(string $id, array $params = [], array $headers = []): RefundCreditNoteResponse;
 
@@ -207,12 +202,10 @@ Interface CreditNoteActionsInterface
     *   @param array<string, string> $headers
     *   @return ListCreditNoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListCreditNoteResponse;
 
@@ -247,12 +240,10 @@ Interface CreditNoteActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateCreditNoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateCreditNoteResponse;
 
@@ -274,12 +265,10 @@ Interface CreditNoteActionsInterface
     *   @param array<string, string> $headers
     *   @return RecordRefundCreditNoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function recordRefund(string $id, array $params, array $headers = []): RecordRefundCreditNoteResponse;
 
@@ -385,12 +374,10 @@ Interface CreditNoteActionsInterface
     *   @param array<string, string> $headers
     *   @return ImportCreditNoteCreditNoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function importCreditNote(array $params, array $headers = []): ImportCreditNoteCreditNoteResponse;
 
@@ -403,12 +390,10 @@ Interface CreditNoteActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteCreditNoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $params = [], array $headers = []): DeleteCreditNoteResponse;
 
@@ -422,12 +407,10 @@ Interface CreditNoteActionsInterface
     *   @param array<string, string> $headers
     *   @return CreditNotesForCustomerCreditNoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function creditNotesForCustomer(string $id, array $params = [], array $headers = []): CreditNotesForCustomerCreditNoteResponse;
 
@@ -438,12 +421,10 @@ Interface CreditNoteActionsInterface
     *   @param array<string, string> $headers
     *   @return DownloadEinvoiceCreditNoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function downloadEinvoice(string $id, array $headers = []): DownloadEinvoiceCreditNoteResponse;
 
@@ -456,12 +437,10 @@ Interface CreditNoteActionsInterface
     *   @param array<string, string> $headers
     *   @return PdfCreditNoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function pdf(string $id, array $params = [], array $headers = []): PdfCreditNoteResponse;
 
@@ -472,12 +451,10 @@ Interface CreditNoteActionsInterface
     *   @param array<string, string> $headers
     *   @return ResendEinvoiceCreditNoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function resendEinvoice(string $id, array $headers = []): ResendEinvoiceCreditNoteResponse;
 
@@ -492,12 +469,10 @@ Interface CreditNoteActionsInterface
     *   @param array<string, string> $headers
     *   @return RemoveTaxWithheldRefundCreditNoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function removeTaxWithheldRefund(string $id, array $params, array $headers = []): RemoveTaxWithheldRefundCreditNoteResponse;
 
@@ -517,12 +492,10 @@ Interface CreditNoteActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveCreditNoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $params = [], array $headers = []): RetrieveCreditNoteResponse;
 
@@ -533,12 +506,10 @@ Interface CreditNoteActionsInterface
     *   @param array<string, string> $headers
     *   @return SendEinvoiceCreditNoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function sendEinvoice(string $id, array $headers = []): SendEinvoiceCreditNoteResponse;
 

--- a/src/Actions/Contracts/CreditNoteActionsInterface.php
+++ b/src/Actions/Contracts/CreditNoteActionsInterface.php
@@ -15,6 +15,12 @@ use Chargebee\Responses\CreditNoteResponse\DeleteCreditNoteResponse;
 use Chargebee\Responses\CreditNoteResponse\PdfCreditNoteResponse;
 use Chargebee\Responses\CreditNoteResponse\RefundCreditNoteResponse;
 use Chargebee\Responses\CreditNoteResponse\RecordRefundCreditNoteResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface CreditNoteActionsInterface
 {
@@ -27,6 +33,13 @@ Interface CreditNoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return VoidCreditNoteCreditNoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function voidCreditNote(string $id, array $params = [], array $headers = []): VoidCreditNoteCreditNoteResponse;
 
@@ -40,6 +53,13 @@ Interface CreditNoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RefundCreditNoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function refund(string $id, array $params = [], array $headers = []): RefundCreditNoteResponse;
 
@@ -186,6 +206,13 @@ Interface CreditNoteActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListCreditNoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListCreditNoteResponse;
 
@@ -219,6 +246,13 @@ Interface CreditNoteActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateCreditNoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateCreditNoteResponse;
 
@@ -239,6 +273,13 @@ Interface CreditNoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RecordRefundCreditNoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function recordRefund(string $id, array $params, array $headers = []): RecordRefundCreditNoteResponse;
 
@@ -343,6 +384,13 @@ Interface CreditNoteActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ImportCreditNoteCreditNoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function importCreditNote(array $params, array $headers = []): ImportCreditNoteCreditNoteResponse;
 
@@ -354,6 +402,13 @@ Interface CreditNoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteCreditNoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $params = [], array $headers = []): DeleteCreditNoteResponse;
 
@@ -366,6 +421,13 @@ Interface CreditNoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CreditNotesForCustomerCreditNoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function creditNotesForCustomer(string $id, array $params = [], array $headers = []): CreditNotesForCustomerCreditNoteResponse;
 
@@ -375,6 +437,13 @@ Interface CreditNoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DownloadEinvoiceCreditNoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function downloadEinvoice(string $id, array $headers = []): DownloadEinvoiceCreditNoteResponse;
 
@@ -386,6 +455,13 @@ Interface CreditNoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return PdfCreditNoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function pdf(string $id, array $params = [], array $headers = []): PdfCreditNoteResponse;
 
@@ -395,6 +471,13 @@ Interface CreditNoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ResendEinvoiceCreditNoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function resendEinvoice(string $id, array $headers = []): ResendEinvoiceCreditNoteResponse;
 
@@ -408,6 +491,13 @@ Interface CreditNoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RemoveTaxWithheldRefundCreditNoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function removeTaxWithheldRefund(string $id, array $params, array $headers = []): RemoveTaxWithheldRefundCreditNoteResponse;
 
@@ -426,6 +516,13 @@ Interface CreditNoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveCreditNoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $params = [], array $headers = []): RetrieveCreditNoteResponse;
 
@@ -435,6 +532,13 @@ Interface CreditNoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return SendEinvoiceCreditNoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function sendEinvoice(string $id, array $headers = []): SendEinvoiceCreditNoteResponse;
 

--- a/src/Actions/Contracts/CurrencyActionsInterface.php
+++ b/src/Actions/Contracts/CurrencyActionsInterface.php
@@ -7,6 +7,12 @@ use Chargebee\Responses\CurrencyResponse\AddScheduleCurrencyResponse;
 use Chargebee\Responses\CurrencyResponse\RetrieveCurrencyResponse;
 use Chargebee\Responses\CurrencyResponse\RemoveScheduleCurrencyResponse;
 use Chargebee\Responses\CurrencyResponse\UpdateCurrencyResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface CurrencyActionsInterface
 {
@@ -20,6 +26,13 @@ Interface CurrencyActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return AddScheduleCurrencyResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function addSchedule(string $id, array $params, array $headers = []): AddScheduleCurrencyResponse;
 
@@ -33,6 +46,13 @@ Interface CurrencyActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateCurrencyResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateCurrencyResponse;
 
@@ -42,6 +62,13 @@ Interface CurrencyActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveCurrencyResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveCurrencyResponse;
 
@@ -54,6 +81,13 @@ Interface CurrencyActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateCurrencyResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params, array $headers = []): UpdateCurrencyResponse;
 
@@ -63,6 +97,13 @@ Interface CurrencyActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RemoveScheduleCurrencyResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function removeSchedule(string $id, array $headers = []): RemoveScheduleCurrencyResponse;
 
@@ -72,6 +113,13 @@ Interface CurrencyActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListCurrencyResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $headers = []): ListCurrencyResponse;
 

--- a/src/Actions/Contracts/CurrencyActionsInterface.php
+++ b/src/Actions/Contracts/CurrencyActionsInterface.php
@@ -8,7 +8,6 @@ use Chargebee\Responses\CurrencyResponse\RetrieveCurrencyResponse;
 use Chargebee\Responses\CurrencyResponse\RemoveScheduleCurrencyResponse;
 use Chargebee\Responses\CurrencyResponse\UpdateCurrencyResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -27,12 +26,10 @@ Interface CurrencyActionsInterface
     *   @param array<string, string> $headers
     *   @return AddScheduleCurrencyResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function addSchedule(string $id, array $params, array $headers = []): AddScheduleCurrencyResponse;
 
@@ -47,12 +44,10 @@ Interface CurrencyActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateCurrencyResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateCurrencyResponse;
 
@@ -63,12 +58,10 @@ Interface CurrencyActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveCurrencyResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveCurrencyResponse;
 
@@ -82,12 +75,10 @@ Interface CurrencyActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateCurrencyResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params, array $headers = []): UpdateCurrencyResponse;
 
@@ -98,12 +89,10 @@ Interface CurrencyActionsInterface
     *   @param array<string, string> $headers
     *   @return RemoveScheduleCurrencyResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function removeSchedule(string $id, array $headers = []): RemoveScheduleCurrencyResponse;
 
@@ -114,12 +103,10 @@ Interface CurrencyActionsInterface
     *   @param array<string, string> $headers
     *   @return ListCurrencyResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $headers = []): ListCurrencyResponse;
 

--- a/src/Actions/Contracts/CustomerActionsInterface.php
+++ b/src/Actions/Contracts/CustomerActionsInterface.php
@@ -28,7 +28,6 @@ use Chargebee\Responses\CustomerResponse\UpdateBillingInfoCustomerResponse;
 use Chargebee\Responses\CustomerResponse\HierarchyCustomerResponse;
 use Chargebee\Responses\CustomerResponse\UpdateCustomerResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -46,12 +45,10 @@ Interface CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $params = [], array $headers = []): DeleteCustomerResponse;
 
@@ -68,12 +65,10 @@ Interface CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return AddPromotionalCreditsCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function addPromotionalCredits(string $id, array $params, array $headers = []): AddPromotionalCreditsCustomerResponse;
 
@@ -103,12 +98,10 @@ Interface CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return RelationshipsCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function relationships(string $id, array $params = [], array $headers = []): RelationshipsCustomerResponse;
 
@@ -119,12 +112,10 @@ Interface CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteRelationshipCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function deleteRelationship(string $id, array $headers = []): DeleteRelationshipCustomerResponse;
 
@@ -139,12 +130,10 @@ Interface CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteContactCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function deleteContact(string $id, array $params, array $headers = []): DeleteContactCustomerResponse;
 
@@ -158,12 +147,10 @@ Interface CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return AssignPaymentRoleCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function assignPaymentRole(string $id, array $params, array $headers = []): AssignPaymentRoleCustomerResponse;
 
@@ -177,12 +164,10 @@ Interface CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return MoveCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function move(array $params, array $headers = []): MoveCustomerResponse;
 
@@ -195,12 +180,10 @@ Interface CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return HierarchyCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function hierarchy(string $id, array $params, array $headers = []): HierarchyCustomerResponse;
 
@@ -221,12 +204,10 @@ Interface CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdatePaymentMethodCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function updatePaymentMethod(string $id, array $params, array $headers = []): UpdatePaymentMethodCustomerResponse;
 
@@ -237,12 +218,10 @@ Interface CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveCustomerResponse;
 
@@ -282,12 +261,10 @@ Interface CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdateCustomerResponse;
 
@@ -302,12 +279,10 @@ Interface CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return ListHierarchyDetailCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function listHierarchyDetail(string $id, array $params, array $headers = []): ListHierarchyDetailCustomerResponse;
 
@@ -324,12 +299,10 @@ Interface CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return ChangeBillingDateCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function changeBillingDate(string $id, array $params = [], array $headers = []): ChangeBillingDateCustomerResponse;
 
@@ -444,12 +417,10 @@ Interface CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return ListCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListCustomerResponse;
 
@@ -580,12 +551,10 @@ Interface CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params = [], array $headers = []): CreateCustomerResponse;
 
@@ -608,12 +577,10 @@ Interface CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return AddContactCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function addContact(string $id, array $params, array $headers = []): AddContactCustomerResponse;
 
@@ -627,12 +594,10 @@ Interface CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return ContactsForCustomerCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function contactsForCustomer(string $id, array $params = [], array $headers = []): ContactsForCustomerCustomerResponse;
 
@@ -649,12 +614,10 @@ Interface CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return DeductPromotionalCreditsCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function deductPromotionalCredits(string $id, array $params, array $headers = []): DeductPromotionalCreditsCustomerResponse;
 
@@ -665,12 +628,10 @@ Interface CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return ClearPersonalDataCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function clearPersonalData(string $id, array $headers = []): ClearPersonalDataCustomerResponse;
 
@@ -684,12 +645,10 @@ Interface CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return MergeCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function merge(array $params, array $headers = []): MergeCustomerResponse;
 
@@ -745,12 +704,10 @@ Interface CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return CollectPaymentCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function collectPayment(string $id, array $params, array $headers = []): CollectPaymentCustomerResponse;
 
@@ -772,12 +729,10 @@ Interface CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return RecordExcessPaymentCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function recordExcessPayment(string $id, array $params, array $headers = []): RecordExcessPaymentCustomerResponse;
 
@@ -794,12 +749,10 @@ Interface CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return SetPromotionalCreditsCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function setPromotionalCredits(string $id, array $params, array $headers = []): SetPromotionalCreditsCustomerResponse;
 
@@ -822,12 +775,10 @@ Interface CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateContactCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function updateContact(string $id, array $params, array $headers = []): UpdateContactCustomerResponse;
 
@@ -854,12 +805,10 @@ Interface CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateHierarchySettingsCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function updateHierarchySettings(string $id, array $params = [], array $headers = []): UpdateHierarchySettingsCustomerResponse;
 
@@ -907,12 +856,10 @@ Interface CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateBillingInfoCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function updateBillingInfo(string $id, array $params = [], array $headers = []): UpdateBillingInfoCustomerResponse;
 

--- a/src/Actions/Contracts/CustomerActionsInterface.php
+++ b/src/Actions/Contracts/CustomerActionsInterface.php
@@ -27,6 +27,12 @@ use Chargebee\Responses\CustomerResponse\CollectPaymentCustomerResponse;
 use Chargebee\Responses\CustomerResponse\UpdateBillingInfoCustomerResponse;
 use Chargebee\Responses\CustomerResponse\HierarchyCustomerResponse;
 use Chargebee\Responses\CustomerResponse\UpdateCustomerResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface CustomerActionsInterface
 {
@@ -39,6 +45,13 @@ Interface CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $params = [], array $headers = []): DeleteCustomerResponse;
 
@@ -54,6 +67,13 @@ Interface CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return AddPromotionalCreditsCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function addPromotionalCredits(string $id, array $params, array $headers = []): AddPromotionalCreditsCustomerResponse;
 
@@ -82,6 +102,13 @@ Interface CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RelationshipsCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function relationships(string $id, array $params = [], array $headers = []): RelationshipsCustomerResponse;
 
@@ -91,6 +118,13 @@ Interface CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteRelationshipCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function deleteRelationship(string $id, array $headers = []): DeleteRelationshipCustomerResponse;
 
@@ -104,6 +138,13 @@ Interface CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteContactCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function deleteContact(string $id, array $params, array $headers = []): DeleteContactCustomerResponse;
 
@@ -116,6 +157,13 @@ Interface CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return AssignPaymentRoleCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function assignPaymentRole(string $id, array $params, array $headers = []): AssignPaymentRoleCustomerResponse;
 
@@ -128,6 +176,13 @@ Interface CustomerActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return MoveCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function move(array $params, array $headers = []): MoveCustomerResponse;
 
@@ -139,6 +194,13 @@ Interface CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return HierarchyCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function hierarchy(string $id, array $params, array $headers = []): HierarchyCustomerResponse;
 
@@ -158,6 +220,13 @@ Interface CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdatePaymentMethodCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function updatePaymentMethod(string $id, array $params, array $headers = []): UpdatePaymentMethodCustomerResponse;
 
@@ -167,6 +236,13 @@ Interface CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveCustomerResponse;
 
@@ -205,6 +281,13 @@ Interface CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdateCustomerResponse;
 
@@ -218,6 +301,13 @@ Interface CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ListHierarchyDetailCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function listHierarchyDetail(string $id, array $params, array $headers = []): ListHierarchyDetailCustomerResponse;
 
@@ -233,6 +323,13 @@ Interface CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ChangeBillingDateCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function changeBillingDate(string $id, array $params = [], array $headers = []): ChangeBillingDateCustomerResponse;
 
@@ -346,6 +443,13 @@ Interface CustomerActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListCustomerResponse;
 
@@ -475,6 +579,13 @@ Interface CustomerActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params = [], array $headers = []): CreateCustomerResponse;
 
@@ -496,6 +607,13 @@ Interface CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return AddContactCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function addContact(string $id, array $params, array $headers = []): AddContactCustomerResponse;
 
@@ -508,6 +626,13 @@ Interface CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ContactsForCustomerCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function contactsForCustomer(string $id, array $params = [], array $headers = []): ContactsForCustomerCustomerResponse;
 
@@ -523,6 +648,13 @@ Interface CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeductPromotionalCreditsCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function deductPromotionalCredits(string $id, array $params, array $headers = []): DeductPromotionalCreditsCustomerResponse;
 
@@ -532,6 +664,13 @@ Interface CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ClearPersonalDataCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function clearPersonalData(string $id, array $headers = []): ClearPersonalDataCustomerResponse;
 
@@ -544,6 +683,13 @@ Interface CustomerActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return MergeCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function merge(array $params, array $headers = []): MergeCustomerResponse;
 
@@ -598,6 +744,13 @@ Interface CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CollectPaymentCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function collectPayment(string $id, array $params, array $headers = []): CollectPaymentCustomerResponse;
 
@@ -618,6 +771,13 @@ Interface CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RecordExcessPaymentCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function recordExcessPayment(string $id, array $params, array $headers = []): RecordExcessPaymentCustomerResponse;
 
@@ -633,6 +793,13 @@ Interface CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return SetPromotionalCreditsCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function setPromotionalCredits(string $id, array $params, array $headers = []): SetPromotionalCreditsCustomerResponse;
 
@@ -654,6 +821,13 @@ Interface CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateContactCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function updateContact(string $id, array $params, array $headers = []): UpdateContactCustomerResponse;
 
@@ -679,6 +853,13 @@ Interface CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateHierarchySettingsCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function updateHierarchySettings(string $id, array $params = [], array $headers = []): UpdateHierarchySettingsCustomerResponse;
 
@@ -725,6 +906,13 @@ Interface CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateBillingInfoCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function updateBillingInfo(string $id, array $params = [], array $headers = []): UpdateBillingInfoCustomerResponse;
 

--- a/src/Actions/Contracts/CustomerEntitlementActionsInterface.php
+++ b/src/Actions/Contracts/CustomerEntitlementActionsInterface.php
@@ -2,6 +2,12 @@
 namespace Chargebee\Actions\Contracts;
     
 use Chargebee\Responses\CustomerEntitlementResponse\EntitlementsForCustomerCustomerEntitlementResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface CustomerEntitlementActionsInterface
 {
@@ -16,6 +22,13 @@ Interface CustomerEntitlementActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return EntitlementsForCustomerCustomerEntitlementResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function entitlementsForCustomer(string $id, array $params = [], array $headers = []): EntitlementsForCustomerCustomerEntitlementResponse;
 

--- a/src/Actions/Contracts/CustomerEntitlementActionsInterface.php
+++ b/src/Actions/Contracts/CustomerEntitlementActionsInterface.php
@@ -3,7 +3,6 @@ namespace Chargebee\Actions\Contracts;
     
 use Chargebee\Responses\CustomerEntitlementResponse\EntitlementsForCustomerCustomerEntitlementResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -23,12 +22,10 @@ Interface CustomerEntitlementActionsInterface
     *   @param array<string, string> $headers
     *   @return EntitlementsForCustomerCustomerEntitlementResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function entitlementsForCustomer(string $id, array $params = [], array $headers = []): EntitlementsForCustomerCustomerEntitlementResponse;
 

--- a/src/Actions/Contracts/DifferentialPriceActionsInterface.php
+++ b/src/Actions/Contracts/DifferentialPriceActionsInterface.php
@@ -6,6 +6,12 @@ use Chargebee\Responses\DifferentialPriceResponse\CreateDifferentialPriceRespons
 use Chargebee\Responses\DifferentialPriceResponse\ListDifferentialPriceResponse;
 use Chargebee\Responses\DifferentialPriceResponse\RetrieveDifferentialPriceResponse;
 use Chargebee\Responses\DifferentialPriceResponse\DeleteDifferentialPriceResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface DifferentialPriceActionsInterface
 {
@@ -18,6 +24,13 @@ Interface DifferentialPriceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteDifferentialPriceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $params, array $headers = []): DeleteDifferentialPriceResponse;
 
@@ -46,6 +59,13 @@ Interface DifferentialPriceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CreateDifferentialPriceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(string $id, array $params, array $headers = []): CreateDifferentialPriceResponse;
 
@@ -86,6 +106,13 @@ Interface DifferentialPriceActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListDifferentialPriceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListDifferentialPriceResponse;
 
@@ -97,6 +124,13 @@ Interface DifferentialPriceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveDifferentialPriceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $params, array $headers = []): RetrieveDifferentialPriceResponse;
 
@@ -124,6 +158,13 @@ Interface DifferentialPriceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateDifferentialPriceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params, array $headers = []): UpdateDifferentialPriceResponse;
 

--- a/src/Actions/Contracts/DifferentialPriceActionsInterface.php
+++ b/src/Actions/Contracts/DifferentialPriceActionsInterface.php
@@ -7,7 +7,6 @@ use Chargebee\Responses\DifferentialPriceResponse\ListDifferentialPriceResponse;
 use Chargebee\Responses\DifferentialPriceResponse\RetrieveDifferentialPriceResponse;
 use Chargebee\Responses\DifferentialPriceResponse\DeleteDifferentialPriceResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -25,12 +24,10 @@ Interface DifferentialPriceActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteDifferentialPriceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $params, array $headers = []): DeleteDifferentialPriceResponse;
 
@@ -60,12 +57,10 @@ Interface DifferentialPriceActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateDifferentialPriceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(string $id, array $params, array $headers = []): CreateDifferentialPriceResponse;
 
@@ -107,12 +102,10 @@ Interface DifferentialPriceActionsInterface
     *   @param array<string, string> $headers
     *   @return ListDifferentialPriceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListDifferentialPriceResponse;
 
@@ -125,12 +118,10 @@ Interface DifferentialPriceActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveDifferentialPriceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $params, array $headers = []): RetrieveDifferentialPriceResponse;
 
@@ -159,12 +150,10 @@ Interface DifferentialPriceActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateDifferentialPriceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params, array $headers = []): UpdateDifferentialPriceResponse;
 

--- a/src/Actions/Contracts/EntitlementActionsInterface.php
+++ b/src/Actions/Contracts/EntitlementActionsInterface.php
@@ -4,7 +4,6 @@ namespace Chargebee\Actions\Contracts;
 use Chargebee\Responses\EntitlementResponse\ListEntitlementResponse;
 use Chargebee\Responses\EntitlementResponse\CreateEntitlementResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -37,12 +36,10 @@ Interface EntitlementActionsInterface
     *   @param array<string, string> $headers
     *   @return ListEntitlementResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListEntitlementResponse;
 
@@ -63,12 +60,10 @@ Interface EntitlementActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateEntitlementResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateEntitlementResponse;
 

--- a/src/Actions/Contracts/EntitlementActionsInterface.php
+++ b/src/Actions/Contracts/EntitlementActionsInterface.php
@@ -3,6 +3,12 @@ namespace Chargebee\Actions\Contracts;
     
 use Chargebee\Responses\EntitlementResponse\ListEntitlementResponse;
 use Chargebee\Responses\EntitlementResponse\CreateEntitlementResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface EntitlementActionsInterface
 {
@@ -13,16 +19,16 @@ Interface EntitlementActionsInterface
     *     limit?: int,
     *     offset?: string,
     *     feature_id?: array{
-    *     is?: mixed,
     *     in?: mixed,
+    *     is?: mixed,
     *     },
     * entity_type?: array{
-    *     is?: mixed,
     *     in?: mixed,
+    *     is?: mixed,
     *     },
     * entity_id?: array{
-    *     is?: mixed,
     *     in?: mixed,
+    *     is?: mixed,
     *     },
     * include_drafts?: bool,
     *     embed?: string,
@@ -30,6 +36,13 @@ Interface EntitlementActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListEntitlementResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListEntitlementResponse;
 
@@ -49,6 +62,13 @@ Interface EntitlementActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateEntitlementResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateEntitlementResponse;
 

--- a/src/Actions/Contracts/EntitlementOverrideActionsInterface.php
+++ b/src/Actions/Contracts/EntitlementOverrideActionsInterface.php
@@ -4,7 +4,6 @@ namespace Chargebee\Actions\Contracts;
 use Chargebee\Responses\EntitlementOverrideResponse\AddEntitlementOverrideForSubscriptionEntitlementOverrideResponse;
 use Chargebee\Responses\EntitlementOverrideResponse\ListEntitlementOverrideForSubscriptionEntitlementOverrideResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -26,12 +25,10 @@ Interface EntitlementOverrideActionsInterface
     *   @param array<string, string> $headers
     *   @return ListEntitlementOverrideForSubscriptionEntitlementOverrideResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function listEntitlementOverrideForSubscription(string $id, array $params = [], array $headers = []): ListEntitlementOverrideForSubscriptionEntitlementOverrideResponse;
 
@@ -50,12 +47,10 @@ Interface EntitlementOverrideActionsInterface
     *   @param array<string, string> $headers
     *   @return AddEntitlementOverrideForSubscriptionEntitlementOverrideResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function addEntitlementOverrideForSubscription(string $id, array $params, array $headers = []): AddEntitlementOverrideForSubscriptionEntitlementOverrideResponse;
 

--- a/src/Actions/Contracts/EntitlementOverrideActionsInterface.php
+++ b/src/Actions/Contracts/EntitlementOverrideActionsInterface.php
@@ -3,6 +3,12 @@ namespace Chargebee\Actions\Contracts;
     
 use Chargebee\Responses\EntitlementOverrideResponse\AddEntitlementOverrideForSubscriptionEntitlementOverrideResponse;
 use Chargebee\Responses\EntitlementOverrideResponse\ListEntitlementOverrideForSubscriptionEntitlementOverrideResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface EntitlementOverrideActionsInterface
 {
@@ -19,6 +25,13 @@ Interface EntitlementOverrideActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ListEntitlementOverrideForSubscriptionEntitlementOverrideResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function listEntitlementOverrideForSubscription(string $id, array $params = [], array $headers = []): ListEntitlementOverrideForSubscriptionEntitlementOverrideResponse;
 
@@ -36,6 +49,13 @@ Interface EntitlementOverrideActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return AddEntitlementOverrideForSubscriptionEntitlementOverrideResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function addEntitlementOverrideForSubscription(string $id, array $params, array $headers = []): AddEntitlementOverrideForSubscriptionEntitlementOverrideResponse;
 

--- a/src/Actions/Contracts/EstimateActionsInterface.php
+++ b/src/Actions/Contracts/EstimateActionsInterface.php
@@ -21,6 +21,12 @@ use Chargebee\Responses\EstimateResponse\AdvanceInvoiceEstimateEstimateResponse;
 use Chargebee\Responses\EstimateResponse\PauseSubscriptionEstimateResponse;
 use Chargebee\Responses\EstimateResponse\ResumeSubscriptionEstimateResponse;
 use Chargebee\Responses\EstimateResponse\CreateSubItemForCustomerEstimateEstimateResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface EstimateActionsInterface
 {
@@ -36,6 +42,13 @@ Interface EstimateActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RenewalEstimateEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function renewalEstimate(string $id, array $params = [], array $headers = []): RenewalEstimateEstimateResponse;
 
@@ -141,6 +154,13 @@ Interface EstimateActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateSubItemEstimateEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createSubItemEstimate(array $params, array $headers = []): CreateSubItemEstimateEstimateResponse;
 
@@ -155,6 +175,13 @@ Interface EstimateActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return PaymentSchedulesEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function paymentSchedules(array $params, array $headers = []): PaymentSchedulesEstimateResponse;
 
@@ -183,6 +210,13 @@ Interface EstimateActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CancelSubscriptionForItemsEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function cancelSubscriptionForItems(string $id, array $params = [], array $headers = []): CancelSubscriptionForItemsEstimateResponse;
 
@@ -198,6 +232,13 @@ Interface EstimateActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ResumeSubscriptionEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function resumeSubscription(string $id, array $params = [], array $headers = []): ResumeSubscriptionEstimateResponse;
 
@@ -299,6 +340,13 @@ Interface EstimateActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateInvoiceForItemsEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createInvoiceForItems(array $params, array $headers = []): CreateInvoiceForItemsEstimateResponse;
 
@@ -358,6 +406,13 @@ Interface EstimateActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return GiftSubscriptionForItemsEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function giftSubscriptionForItems(array $params, array $headers = []): GiftSubscriptionForItemsEstimateResponse;
 
@@ -468,6 +523,13 @@ Interface EstimateActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return UpdateSubscriptionForItemsEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function updateSubscriptionForItems(array $params, array $headers = []): UpdateSubscriptionForItemsEstimateResponse;
 
@@ -477,6 +539,13 @@ Interface EstimateActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpcomingInvoicesEstimateEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function upcomingInvoicesEstimate(string $id, array $headers = []): UpcomingInvoicesEstimateEstimateResponse;
 
@@ -491,6 +560,13 @@ Interface EstimateActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RegenerateInvoiceEstimateEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function regenerateInvoiceEstimate(string $id, array $params = [], array $headers = []): RegenerateInvoiceEstimateEstimateResponse;
 
@@ -584,6 +660,13 @@ Interface EstimateActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CreateSubItemForCustomerEstimateEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createSubItemForCustomerEstimate(string $id, array $params, array $headers = []): CreateSubItemForCustomerEstimateEstimateResponse;
 
@@ -597,6 +680,13 @@ Interface EstimateActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ChangeTermEndEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function changeTermEnd(string $id, array $params, array $headers = []): ChangeTermEndEstimateResponse;
 
@@ -614,6 +704,13 @@ Interface EstimateActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return PauseSubscriptionEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function pauseSubscription(string $id, array $params = [], array $headers = []): PauseSubscriptionEstimateResponse;
 
@@ -637,6 +734,13 @@ Interface EstimateActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return AdvanceInvoiceEstimateEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function advanceInvoiceEstimate(string $id, array $params = [], array $headers = []): AdvanceInvoiceEstimateEstimateResponse;
 
@@ -729,6 +833,13 @@ Interface EstimateActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return UpdateSubscriptionEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function updateSubscription(array $params, array $headers = []): UpdateSubscriptionEstimateResponse;
 
@@ -793,6 +904,13 @@ Interface EstimateActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return GiftSubscriptionEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function giftSubscription(array $params, array $headers = []): GiftSubscriptionEstimateResponse;
 
@@ -861,6 +979,13 @@ Interface EstimateActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CreateSubForCustomerEstimateEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createSubForCustomerEstimate(string $id, array $params, array $headers = []): CreateSubForCustomerEstimateEstimateResponse;
 
@@ -955,6 +1080,13 @@ Interface EstimateActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateSubscriptionEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createSubscription(array $params, array $headers = []): CreateSubscriptionEstimateResponse;
 
@@ -1028,6 +1160,13 @@ Interface EstimateActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateInvoiceEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createInvoice(array $params = [], array $headers = []): CreateInvoiceEstimateResponse;
 
@@ -1054,6 +1193,13 @@ Interface EstimateActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CancelSubscriptionEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function cancelSubscription(string $id, array $params = [], array $headers = []): CancelSubscriptionEstimateResponse;
 

--- a/src/Actions/Contracts/EstimateActionsInterface.php
+++ b/src/Actions/Contracts/EstimateActionsInterface.php
@@ -22,7 +22,6 @@ use Chargebee\Responses\EstimateResponse\PauseSubscriptionEstimateResponse;
 use Chargebee\Responses\EstimateResponse\ResumeSubscriptionEstimateResponse;
 use Chargebee\Responses\EstimateResponse\CreateSubItemForCustomerEstimateEstimateResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -43,12 +42,10 @@ Interface EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return RenewalEstimateEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function renewalEstimate(string $id, array $params = [], array $headers = []): RenewalEstimateEstimateResponse;
 
@@ -155,12 +152,10 @@ Interface EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateSubItemEstimateEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createSubItemEstimate(array $params, array $headers = []): CreateSubItemEstimateEstimateResponse;
 
@@ -176,12 +171,10 @@ Interface EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return PaymentSchedulesEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function paymentSchedules(array $params, array $headers = []): PaymentSchedulesEstimateResponse;
 
@@ -211,12 +204,10 @@ Interface EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return CancelSubscriptionForItemsEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function cancelSubscriptionForItems(string $id, array $params = [], array $headers = []): CancelSubscriptionForItemsEstimateResponse;
 
@@ -233,12 +224,10 @@ Interface EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return ResumeSubscriptionEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function resumeSubscription(string $id, array $params = [], array $headers = []): ResumeSubscriptionEstimateResponse;
 
@@ -341,12 +330,10 @@ Interface EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateInvoiceForItemsEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createInvoiceForItems(array $params, array $headers = []): CreateInvoiceForItemsEstimateResponse;
 
@@ -407,12 +394,10 @@ Interface EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return GiftSubscriptionForItemsEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function giftSubscriptionForItems(array $params, array $headers = []): GiftSubscriptionForItemsEstimateResponse;
 
@@ -524,12 +509,10 @@ Interface EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateSubscriptionForItemsEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function updateSubscriptionForItems(array $params, array $headers = []): UpdateSubscriptionForItemsEstimateResponse;
 
@@ -540,12 +523,10 @@ Interface EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return UpcomingInvoicesEstimateEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function upcomingInvoicesEstimate(string $id, array $headers = []): UpcomingInvoicesEstimateEstimateResponse;
 
@@ -561,12 +542,10 @@ Interface EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return RegenerateInvoiceEstimateEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function regenerateInvoiceEstimate(string $id, array $params = [], array $headers = []): RegenerateInvoiceEstimateEstimateResponse;
 
@@ -661,12 +640,10 @@ Interface EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateSubItemForCustomerEstimateEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createSubItemForCustomerEstimate(string $id, array $params, array $headers = []): CreateSubItemForCustomerEstimateEstimateResponse;
 
@@ -681,12 +658,10 @@ Interface EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return ChangeTermEndEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function changeTermEnd(string $id, array $params, array $headers = []): ChangeTermEndEstimateResponse;
 
@@ -705,12 +680,10 @@ Interface EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return PauseSubscriptionEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function pauseSubscription(string $id, array $params = [], array $headers = []): PauseSubscriptionEstimateResponse;
 
@@ -735,12 +708,10 @@ Interface EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return AdvanceInvoiceEstimateEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function advanceInvoiceEstimate(string $id, array $params = [], array $headers = []): AdvanceInvoiceEstimateEstimateResponse;
 
@@ -834,12 +805,10 @@ Interface EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateSubscriptionEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function updateSubscription(array $params, array $headers = []): UpdateSubscriptionEstimateResponse;
 
@@ -905,12 +874,10 @@ Interface EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return GiftSubscriptionEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function giftSubscription(array $params, array $headers = []): GiftSubscriptionEstimateResponse;
 
@@ -980,12 +947,10 @@ Interface EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateSubForCustomerEstimateEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createSubForCustomerEstimate(string $id, array $params, array $headers = []): CreateSubForCustomerEstimateEstimateResponse;
 
@@ -1081,12 +1046,10 @@ Interface EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateSubscriptionEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createSubscription(array $params, array $headers = []): CreateSubscriptionEstimateResponse;
 
@@ -1161,12 +1124,10 @@ Interface EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateInvoiceEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createInvoice(array $params = [], array $headers = []): CreateInvoiceEstimateResponse;
 
@@ -1194,12 +1155,10 @@ Interface EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return CancelSubscriptionEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function cancelSubscription(string $id, array $params = [], array $headers = []): CancelSubscriptionEstimateResponse;
 

--- a/src/Actions/Contracts/EventActionsInterface.php
+++ b/src/Actions/Contracts/EventActionsInterface.php
@@ -4,7 +4,6 @@ namespace Chargebee\Actions\Contracts;
 use Chargebee\Responses\EventResponse\RetrieveEventResponse;
 use Chargebee\Responses\EventResponse\ListEventResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -60,12 +59,10 @@ Interface EventActionsInterface
     *   @param array<string, string> $headers
     *   @return ListEventResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListEventResponse;
 
@@ -76,12 +73,10 @@ Interface EventActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveEventResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveEventResponse;
 

--- a/src/Actions/Contracts/EventActionsInterface.php
+++ b/src/Actions/Contracts/EventActionsInterface.php
@@ -3,6 +3,12 @@ namespace Chargebee\Actions\Contracts;
     
 use Chargebee\Responses\EventResponse\RetrieveEventResponse;
 use Chargebee\Responses\EventResponse\ListEventResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface EventActionsInterface
 {
@@ -53,6 +59,13 @@ Interface EventActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListEventResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListEventResponse;
 
@@ -62,6 +75,13 @@ Interface EventActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveEventResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveEventResponse;
 

--- a/src/Actions/Contracts/ExportActionsInterface.php
+++ b/src/Actions/Contracts/ExportActionsInterface.php
@@ -19,6 +19,12 @@ use Chargebee\Responses\ExportResponse\ItemPricesExportResponse;
 use Chargebee\Responses\ExportResponse\TransactionsExportResponse;
 use Chargebee\Responses\ExportResponse\ItemsExportResponse;
 use Chargebee\Responses\ExportResponse\DeferredRevenueExportResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface ExportActionsInterface
 {
@@ -131,6 +137,13 @@ Interface ExportActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CustomersExportResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function customers(array $params = [], array $headers = []): CustomersExportResponse;
 
@@ -188,6 +201,13 @@ Interface ExportActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return AttachedItemsExportResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function attachedItems(array $params = [], array $headers = []): AttachedItemsExportResponse;
 
@@ -303,6 +323,13 @@ Interface ExportActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return TransactionsExportResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function transactions(array $params = [], array $headers = []): TransactionsExportResponse;
 
@@ -343,6 +370,13 @@ Interface ExportActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return DifferentialPricesExportResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function differentialPrices(array $params = [], array $headers = []): DifferentialPricesExportResponse;
 
@@ -380,6 +414,13 @@ Interface ExportActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ItemFamiliesExportResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function itemFamilies(array $params = [], array $headers = []): ItemFamiliesExportResponse;
 
@@ -512,6 +553,13 @@ Interface ExportActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return InvoicesExportResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function invoices(array $params = [], array $headers = []): InvoicesExportResponse;
 
@@ -521,6 +569,13 @@ Interface ExportActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveExportResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveExportResponse;
 
@@ -572,6 +627,13 @@ Interface ExportActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return PriceVariantsExportResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function priceVariants(array $params = [], array $headers = []): PriceVariantsExportResponse;
 
@@ -658,6 +720,13 @@ Interface ExportActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ItemsExportResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function items(array $params = [], array $headers = []): ItemsExportResponse;
 
@@ -998,6 +1067,13 @@ Interface ExportActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return DeferredRevenueExportResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function deferredRevenue(array $params, array $headers = []): DeferredRevenueExportResponse;
 
@@ -1338,6 +1414,13 @@ Interface ExportActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return RevenueRecognitionExportResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function revenueRecognition(array $params, array $headers = []): RevenueRecognitionExportResponse;
 
@@ -1471,6 +1554,13 @@ Interface ExportActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreditNotesExportResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function creditNotes(array $params = [], array $headers = []): CreditNotesExportResponse;
 
@@ -1540,6 +1630,13 @@ Interface ExportActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CouponsExportResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function coupons(array $params = [], array $headers = []): CouponsExportResponse;
 
@@ -1672,6 +1769,13 @@ Interface ExportActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return OrdersExportResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function orders(array $params = [], array $headers = []): OrdersExportResponse;
 
@@ -1793,6 +1897,13 @@ Interface ExportActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ItemPricesExportResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function itemPrices(array $params = [], array $headers = []): ItemPricesExportResponse;
 
@@ -1920,6 +2031,13 @@ Interface ExportActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return SubscriptionsExportResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function subscriptions(array $params = [], array $headers = []): SubscriptionsExportResponse;
 
@@ -2001,6 +2119,13 @@ Interface ExportActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return AddonsExportResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function addons(array $params = [], array $headers = []): AddonsExportResponse;
 
@@ -2101,6 +2226,13 @@ Interface ExportActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return PlansExportResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function plans(array $params = [], array $headers = []): PlansExportResponse;
 

--- a/src/Actions/Contracts/ExportActionsInterface.php
+++ b/src/Actions/Contracts/ExportActionsInterface.php
@@ -20,7 +20,6 @@ use Chargebee\Responses\ExportResponse\TransactionsExportResponse;
 use Chargebee\Responses\ExportResponse\ItemsExportResponse;
 use Chargebee\Responses\ExportResponse\DeferredRevenueExportResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -138,12 +137,10 @@ Interface ExportActionsInterface
     *   @param array<string, string> $headers
     *   @return CustomersExportResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function customers(array $params = [], array $headers = []): CustomersExportResponse;
 
@@ -202,12 +199,10 @@ Interface ExportActionsInterface
     *   @param array<string, string> $headers
     *   @return AttachedItemsExportResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function attachedItems(array $params = [], array $headers = []): AttachedItemsExportResponse;
 
@@ -324,12 +319,10 @@ Interface ExportActionsInterface
     *   @param array<string, string> $headers
     *   @return TransactionsExportResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function transactions(array $params = [], array $headers = []): TransactionsExportResponse;
 
@@ -371,12 +364,10 @@ Interface ExportActionsInterface
     *   @param array<string, string> $headers
     *   @return DifferentialPricesExportResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function differentialPrices(array $params = [], array $headers = []): DifferentialPricesExportResponse;
 
@@ -415,12 +406,10 @@ Interface ExportActionsInterface
     *   @param array<string, string> $headers
     *   @return ItemFamiliesExportResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function itemFamilies(array $params = [], array $headers = []): ItemFamiliesExportResponse;
 
@@ -554,12 +543,10 @@ Interface ExportActionsInterface
     *   @param array<string, string> $headers
     *   @return InvoicesExportResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function invoices(array $params = [], array $headers = []): InvoicesExportResponse;
 
@@ -570,12 +557,10 @@ Interface ExportActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveExportResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveExportResponse;
 
@@ -628,12 +613,10 @@ Interface ExportActionsInterface
     *   @param array<string, string> $headers
     *   @return PriceVariantsExportResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function priceVariants(array $params = [], array $headers = []): PriceVariantsExportResponse;
 
@@ -721,12 +704,10 @@ Interface ExportActionsInterface
     *   @param array<string, string> $headers
     *   @return ItemsExportResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function items(array $params = [], array $headers = []): ItemsExportResponse;
 
@@ -1068,12 +1049,10 @@ Interface ExportActionsInterface
     *   @param array<string, string> $headers
     *   @return DeferredRevenueExportResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function deferredRevenue(array $params, array $headers = []): DeferredRevenueExportResponse;
 
@@ -1415,12 +1394,10 @@ Interface ExportActionsInterface
     *   @param array<string, string> $headers
     *   @return RevenueRecognitionExportResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function revenueRecognition(array $params, array $headers = []): RevenueRecognitionExportResponse;
 
@@ -1555,12 +1532,10 @@ Interface ExportActionsInterface
     *   @param array<string, string> $headers
     *   @return CreditNotesExportResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function creditNotes(array $params = [], array $headers = []): CreditNotesExportResponse;
 
@@ -1631,12 +1606,10 @@ Interface ExportActionsInterface
     *   @param array<string, string> $headers
     *   @return CouponsExportResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function coupons(array $params = [], array $headers = []): CouponsExportResponse;
 
@@ -1770,12 +1743,10 @@ Interface ExportActionsInterface
     *   @param array<string, string> $headers
     *   @return OrdersExportResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function orders(array $params = [], array $headers = []): OrdersExportResponse;
 
@@ -1898,12 +1869,10 @@ Interface ExportActionsInterface
     *   @param array<string, string> $headers
     *   @return ItemPricesExportResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function itemPrices(array $params = [], array $headers = []): ItemPricesExportResponse;
 
@@ -2032,12 +2001,10 @@ Interface ExportActionsInterface
     *   @param array<string, string> $headers
     *   @return SubscriptionsExportResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function subscriptions(array $params = [], array $headers = []): SubscriptionsExportResponse;
 
@@ -2120,12 +2087,10 @@ Interface ExportActionsInterface
     *   @param array<string, string> $headers
     *   @return AddonsExportResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function addons(array $params = [], array $headers = []): AddonsExportResponse;
 
@@ -2227,12 +2192,10 @@ Interface ExportActionsInterface
     *   @param array<string, string> $headers
     *   @return PlansExportResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function plans(array $params = [], array $headers = []): PlansExportResponse;
 

--- a/src/Actions/Contracts/FeatureActionsInterface.php
+++ b/src/Actions/Contracts/FeatureActionsInterface.php
@@ -9,6 +9,12 @@ use Chargebee\Responses\FeatureResponse\DeleteFeatureResponse;
 use Chargebee\Responses\FeatureResponse\UpdateFeatureResponse;
 use Chargebee\Responses\FeatureResponse\ArchiveFeatureResponse;
 use Chargebee\Responses\FeatureResponse\RetrieveFeatureResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface FeatureActionsInterface
 {
@@ -48,6 +54,13 @@ Interface FeatureActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListFeatureResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListFeatureResponse;
 
@@ -69,6 +82,13 @@ Interface FeatureActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateFeatureResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateFeatureResponse;
 
@@ -78,6 +98,13 @@ Interface FeatureActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteFeatureResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteFeatureResponse;
 
@@ -87,6 +114,13 @@ Interface FeatureActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveFeatureResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveFeatureResponse;
 
@@ -106,6 +140,13 @@ Interface FeatureActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateFeatureResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdateFeatureResponse;
 
@@ -115,6 +156,13 @@ Interface FeatureActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ArchiveFeatureResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function archive(string $id, array $headers = []): ArchiveFeatureResponse;
 
@@ -124,6 +172,13 @@ Interface FeatureActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ActivateFeatureResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function activate(string $id, array $headers = []): ActivateFeatureResponse;
 
@@ -133,6 +188,13 @@ Interface FeatureActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ReactivateFeatureResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function reactivate(string $id, array $headers = []): ReactivateFeatureResponse;
 

--- a/src/Actions/Contracts/FeatureActionsInterface.php
+++ b/src/Actions/Contracts/FeatureActionsInterface.php
@@ -10,7 +10,6 @@ use Chargebee\Responses\FeatureResponse\UpdateFeatureResponse;
 use Chargebee\Responses\FeatureResponse\ArchiveFeatureResponse;
 use Chargebee\Responses\FeatureResponse\RetrieveFeatureResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -55,12 +54,10 @@ Interface FeatureActionsInterface
     *   @param array<string, string> $headers
     *   @return ListFeatureResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListFeatureResponse;
 
@@ -83,12 +80,10 @@ Interface FeatureActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateFeatureResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateFeatureResponse;
 
@@ -99,12 +94,10 @@ Interface FeatureActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteFeatureResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteFeatureResponse;
 
@@ -115,12 +108,10 @@ Interface FeatureActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveFeatureResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveFeatureResponse;
 
@@ -141,12 +132,10 @@ Interface FeatureActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateFeatureResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdateFeatureResponse;
 
@@ -157,12 +146,10 @@ Interface FeatureActionsInterface
     *   @param array<string, string> $headers
     *   @return ArchiveFeatureResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function archive(string $id, array $headers = []): ArchiveFeatureResponse;
 
@@ -173,12 +160,10 @@ Interface FeatureActionsInterface
     *   @param array<string, string> $headers
     *   @return ActivateFeatureResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function activate(string $id, array $headers = []): ActivateFeatureResponse;
 
@@ -189,12 +174,10 @@ Interface FeatureActionsInterface
     *   @param array<string, string> $headers
     *   @return ReactivateFeatureResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function reactivate(string $id, array $headers = []): ReactivateFeatureResponse;
 

--- a/src/Actions/Contracts/GiftActionsInterface.php
+++ b/src/Actions/Contracts/GiftActionsInterface.php
@@ -8,6 +8,12 @@ use Chargebee\Responses\GiftResponse\ClaimGiftResponse;
 use Chargebee\Responses\GiftResponse\RetrieveGiftResponse;
 use Chargebee\Responses\GiftResponse\CancelGiftResponse;
 use Chargebee\Responses\GiftResponse\CreateGiftResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface GiftActionsInterface
 {
@@ -66,6 +72,13 @@ Interface GiftActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateForItemsGiftResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createForItems(array $params, array $headers = []): CreateForItemsGiftResponse;
 
@@ -75,6 +88,13 @@ Interface GiftActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CancelGiftResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function cancel(string $id, array $headers = []): CancelGiftResponse;
 
@@ -87,6 +107,13 @@ Interface GiftActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateGiftGiftResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function updateGift(string $id, array $params, array $headers = []): UpdateGiftGiftResponse;
 
@@ -124,6 +151,13 @@ Interface GiftActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListGiftResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListGiftResponse;
 
@@ -186,6 +220,13 @@ Interface GiftActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateGiftResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateGiftResponse;
 
@@ -195,6 +236,13 @@ Interface GiftActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveGiftResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveGiftResponse;
 
@@ -204,6 +252,13 @@ Interface GiftActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ClaimGiftResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function claim(string $id, array $headers = []): ClaimGiftResponse;
 

--- a/src/Actions/Contracts/GiftActionsInterface.php
+++ b/src/Actions/Contracts/GiftActionsInterface.php
@@ -9,7 +9,6 @@ use Chargebee\Responses\GiftResponse\RetrieveGiftResponse;
 use Chargebee\Responses\GiftResponse\CancelGiftResponse;
 use Chargebee\Responses\GiftResponse\CreateGiftResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -73,12 +72,10 @@ Interface GiftActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateForItemsGiftResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createForItems(array $params, array $headers = []): CreateForItemsGiftResponse;
 
@@ -89,12 +86,10 @@ Interface GiftActionsInterface
     *   @param array<string, string> $headers
     *   @return CancelGiftResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function cancel(string $id, array $headers = []): CancelGiftResponse;
 
@@ -108,12 +103,10 @@ Interface GiftActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateGiftGiftResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function updateGift(string $id, array $params, array $headers = []): UpdateGiftGiftResponse;
 
@@ -152,12 +145,10 @@ Interface GiftActionsInterface
     *   @param array<string, string> $headers
     *   @return ListGiftResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListGiftResponse;
 
@@ -221,12 +212,10 @@ Interface GiftActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateGiftResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateGiftResponse;
 
@@ -237,12 +226,10 @@ Interface GiftActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveGiftResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveGiftResponse;
 
@@ -253,12 +240,10 @@ Interface GiftActionsInterface
     *   @param array<string, string> $headers
     *   @return ClaimGiftResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function claim(string $id, array $headers = []): ClaimGiftResponse;
 

--- a/src/Actions/Contracts/HostedPageActionsInterface.php
+++ b/src/Actions/Contracts/HostedPageActionsInterface.php
@@ -23,6 +23,12 @@ use Chargebee\Responses\HostedPageResponse\CheckoutGiftHostedPageResponse;
 use Chargebee\Responses\HostedPageResponse\CheckoutExistingForItemsHostedPageResponse;
 use Chargebee\Responses\HostedPageResponse\CheckoutNewHostedPageResponse;
 use Chargebee\Responses\HostedPageResponse\RetrieveHostedPageResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface HostedPageActionsInterface
 {
@@ -148,6 +154,13 @@ Interface HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CheckoutOneTimeForItemsHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function checkoutOneTimeForItems(array $params, array $headers = []): CheckoutOneTimeForItemsHostedPageResponse;
 
@@ -172,6 +185,13 @@ Interface HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return UpdatePaymentMethodHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function updatePaymentMethod(array $params, array $headers = []): UpdatePaymentMethodHostedPageResponse;
 
@@ -196,6 +216,13 @@ Interface HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return UpdateCardHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function updateCard(array $params, array $headers = []): UpdateCardHostedPageResponse;
 
@@ -211,6 +238,13 @@ Interface HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ExtendSubscriptionHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function extendSubscription(array $params, array $headers = []): ExtendSubscriptionHostedPageResponse;
 
@@ -224,6 +258,13 @@ Interface HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return EventsHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function events(array $params, array $headers = []): EventsHostedPageResponse;
 
@@ -245,6 +286,13 @@ Interface HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CheckoutGiftForItemsHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function checkoutGiftForItems(array $params = [], array $headers = []): CheckoutGiftForItemsHostedPageResponse;
 
@@ -282,6 +330,13 @@ Interface HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListHostedPageResponse;
 
@@ -298,6 +353,13 @@ Interface HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ViewVoucherHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function viewVoucher(array $params, array $headers = []): ViewVoucherHostedPageResponse;
 
@@ -317,6 +379,13 @@ Interface HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CollectNowHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function collectNow(array $params, array $headers = []): CollectNowHostedPageResponse;
 
@@ -332,6 +401,13 @@ Interface HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return AcceptQuoteHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function acceptQuote(array $params, array $headers = []): AcceptQuoteHostedPageResponse;
 
@@ -463,6 +539,13 @@ Interface HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CheckoutNewForItemsHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function checkoutNewForItems(array $params, array $headers = []): CheckoutNewForItemsHostedPageResponse;
 
@@ -480,6 +563,13 @@ Interface HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ClaimGiftHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function claimGift(array $params, array $headers = []): ClaimGiftHostedPageResponse;
 
@@ -579,6 +669,13 @@ Interface HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CheckoutExistingForItemsHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function checkoutExistingForItems(array $params, array $headers = []): CheckoutExistingForItemsHostedPageResponse;
 
@@ -595,6 +692,13 @@ Interface HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return PreCancelHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function preCancel(array $params, array $headers = []): PreCancelHostedPageResponse;
 
@@ -604,6 +708,13 @@ Interface HostedPageActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return AcknowledgeHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function acknowledge(string $id, array $headers = []): AcknowledgeHostedPageResponse;
 
@@ -615,6 +726,13 @@ Interface HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return RetrieveAgreementPdfHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieveAgreementPdf(array $params, array $headers = []): RetrieveAgreementPdfHostedPageResponse;
 
@@ -624,6 +742,13 @@ Interface HostedPageActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveHostedPageResponse;
 
@@ -642,6 +767,13 @@ Interface HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ManagePaymentSourcesHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function managePaymentSources(array $params, array $headers = []): ManagePaymentSourcesHostedPageResponse;
 
@@ -737,6 +869,13 @@ Interface HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CheckoutOneTimeHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function checkoutOneTime(array $params = [], array $headers = []): CheckoutOneTimeHostedPageResponse;
 
@@ -847,6 +986,13 @@ Interface HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CheckoutNewHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function checkoutNew(array $params, array $headers = []): CheckoutNewHostedPageResponse;
 
@@ -873,6 +1019,13 @@ Interface HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CheckoutGiftHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function checkoutGift(array $params, array $headers = []): CheckoutGiftHostedPageResponse;
 
@@ -947,6 +1100,13 @@ Interface HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CheckoutExistingHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function checkoutExisting(array $params, array $headers = []): CheckoutExistingHostedPageResponse;
 

--- a/src/Actions/Contracts/HostedPageActionsInterface.php
+++ b/src/Actions/Contracts/HostedPageActionsInterface.php
@@ -24,7 +24,6 @@ use Chargebee\Responses\HostedPageResponse\CheckoutExistingForItemsHostedPageRes
 use Chargebee\Responses\HostedPageResponse\CheckoutNewHostedPageResponse;
 use Chargebee\Responses\HostedPageResponse\RetrieveHostedPageResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -155,12 +154,10 @@ Interface HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return CheckoutOneTimeForItemsHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function checkoutOneTimeForItems(array $params, array $headers = []): CheckoutOneTimeForItemsHostedPageResponse;
 
@@ -186,12 +183,10 @@ Interface HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdatePaymentMethodHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function updatePaymentMethod(array $params, array $headers = []): UpdatePaymentMethodHostedPageResponse;
 
@@ -217,12 +212,10 @@ Interface HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateCardHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function updateCard(array $params, array $headers = []): UpdateCardHostedPageResponse;
 
@@ -239,12 +232,10 @@ Interface HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return ExtendSubscriptionHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function extendSubscription(array $params, array $headers = []): ExtendSubscriptionHostedPageResponse;
 
@@ -259,12 +250,10 @@ Interface HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return EventsHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function events(array $params, array $headers = []): EventsHostedPageResponse;
 
@@ -287,12 +276,10 @@ Interface HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return CheckoutGiftForItemsHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function checkoutGiftForItems(array $params = [], array $headers = []): CheckoutGiftForItemsHostedPageResponse;
 
@@ -331,12 +318,10 @@ Interface HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return ListHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListHostedPageResponse;
 
@@ -354,12 +339,10 @@ Interface HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return ViewVoucherHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function viewVoucher(array $params, array $headers = []): ViewVoucherHostedPageResponse;
 
@@ -380,12 +363,10 @@ Interface HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return CollectNowHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function collectNow(array $params, array $headers = []): CollectNowHostedPageResponse;
 
@@ -402,12 +383,10 @@ Interface HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return AcceptQuoteHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function acceptQuote(array $params, array $headers = []): AcceptQuoteHostedPageResponse;
 
@@ -540,12 +519,10 @@ Interface HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return CheckoutNewForItemsHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function checkoutNewForItems(array $params, array $headers = []): CheckoutNewForItemsHostedPageResponse;
 
@@ -564,12 +541,10 @@ Interface HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return ClaimGiftHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function claimGift(array $params, array $headers = []): ClaimGiftHostedPageResponse;
 
@@ -670,12 +645,10 @@ Interface HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return CheckoutExistingForItemsHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function checkoutExistingForItems(array $params, array $headers = []): CheckoutExistingForItemsHostedPageResponse;
 
@@ -693,12 +666,10 @@ Interface HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return PreCancelHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function preCancel(array $params, array $headers = []): PreCancelHostedPageResponse;
 
@@ -709,12 +680,10 @@ Interface HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return AcknowledgeHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function acknowledge(string $id, array $headers = []): AcknowledgeHostedPageResponse;
 
@@ -727,12 +696,10 @@ Interface HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveAgreementPdfHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieveAgreementPdf(array $params, array $headers = []): RetrieveAgreementPdfHostedPageResponse;
 
@@ -743,12 +710,10 @@ Interface HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveHostedPageResponse;
 
@@ -768,12 +733,10 @@ Interface HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return ManagePaymentSourcesHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function managePaymentSources(array $params, array $headers = []): ManagePaymentSourcesHostedPageResponse;
 
@@ -870,12 +833,10 @@ Interface HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return CheckoutOneTimeHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function checkoutOneTime(array $params = [], array $headers = []): CheckoutOneTimeHostedPageResponse;
 
@@ -987,12 +948,10 @@ Interface HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return CheckoutNewHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function checkoutNew(array $params, array $headers = []): CheckoutNewHostedPageResponse;
 
@@ -1020,12 +979,10 @@ Interface HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return CheckoutGiftHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function checkoutGift(array $params, array $headers = []): CheckoutGiftHostedPageResponse;
 
@@ -1101,12 +1058,10 @@ Interface HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return CheckoutExistingHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function checkoutExisting(array $params, array $headers = []): CheckoutExistingHostedPageResponse;
 

--- a/src/Actions/Contracts/InAppSubscriptionActionsInterface.php
+++ b/src/Actions/Contracts/InAppSubscriptionActionsInterface.php
@@ -5,6 +5,12 @@ use Chargebee\Responses\InAppSubscriptionResponse\ImportSubscriptionInAppSubscri
 use Chargebee\Responses\InAppSubscriptionResponse\RetrieveStoreSubsInAppSubscriptionResponse;
 use Chargebee\Responses\InAppSubscriptionResponse\ProcessReceiptInAppSubscriptionResponse;
 use Chargebee\Responses\InAppSubscriptionResponse\ImportReceiptInAppSubscriptionResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface InAppSubscriptionActionsInterface
 {
@@ -17,6 +23,13 @@ Interface InAppSubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveStoreSubsInAppSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieveStoreSubs(string $id, array $params, array $headers = []): RetrieveStoreSubsInAppSubscriptionResponse;
 
@@ -35,6 +48,13 @@ Interface InAppSubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ImportReceiptInAppSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function importReceipt(string $id, array $params, array $headers = []): ImportReceiptInAppSubscriptionResponse;
 
@@ -59,6 +79,13 @@ Interface InAppSubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ImportSubscriptionInAppSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function importSubscription(string $id, array $params, array $headers = []): ImportSubscriptionInAppSubscriptionResponse;
 
@@ -85,6 +112,13 @@ Interface InAppSubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ProcessReceiptInAppSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function processReceipt(string $id, array $params, array $headers = []): ProcessReceiptInAppSubscriptionResponse;
 

--- a/src/Actions/Contracts/InAppSubscriptionActionsInterface.php
+++ b/src/Actions/Contracts/InAppSubscriptionActionsInterface.php
@@ -6,7 +6,6 @@ use Chargebee\Responses\InAppSubscriptionResponse\RetrieveStoreSubsInAppSubscrip
 use Chargebee\Responses\InAppSubscriptionResponse\ProcessReceiptInAppSubscriptionResponse;
 use Chargebee\Responses\InAppSubscriptionResponse\ImportReceiptInAppSubscriptionResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -24,12 +23,10 @@ Interface InAppSubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveStoreSubsInAppSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieveStoreSubs(string $id, array $params, array $headers = []): RetrieveStoreSubsInAppSubscriptionResponse;
 
@@ -49,12 +46,10 @@ Interface InAppSubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return ImportReceiptInAppSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function importReceipt(string $id, array $params, array $headers = []): ImportReceiptInAppSubscriptionResponse;
 
@@ -80,12 +75,10 @@ Interface InAppSubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return ImportSubscriptionInAppSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function importSubscription(string $id, array $params, array $headers = []): ImportSubscriptionInAppSubscriptionResponse;
 
@@ -113,12 +106,10 @@ Interface InAppSubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return ProcessReceiptInAppSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function processReceipt(string $id, array $params, array $headers = []): ProcessReceiptInAppSubscriptionResponse;
 

--- a/src/Actions/Contracts/InvoiceActionsInterface.php
+++ b/src/Actions/Contracts/InvoiceActionsInterface.php
@@ -41,6 +41,12 @@ use Chargebee\Responses\InvoiceResponse\CreateForChargeItemInvoiceResponse;
 use Chargebee\Responses\InvoiceResponse\RemoveCreditNoteInvoiceResponse;
 use Chargebee\Responses\InvoiceResponse\ImportInvoiceInvoiceResponse;
 use Chargebee\Responses\InvoiceResponse\RefundInvoiceResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface InvoiceActionsInterface
 {
@@ -55,6 +61,13 @@ Interface InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteLineItemsInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function deleteLineItems(string $id, array $params = [], array $headers = []): DeleteLineItemsInvoiceResponse;
 
@@ -68,6 +81,13 @@ Interface InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RemoveCreditNoteInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function removeCreditNote(string $id, array $params, array $headers = []): RemoveCreditNoteInvoiceResponse;
 
@@ -81,6 +101,13 @@ Interface InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RemovePaymentInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function removePayment(string $id, array $params, array $headers = []): RemovePaymentInvoiceResponse;
 
@@ -92,6 +119,13 @@ Interface InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return StopDunningInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function stopDunning(string $id, array $params = [], array $headers = []): StopDunningInvoiceResponse;
 
@@ -107,6 +141,13 @@ Interface InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ApplyPaymentsInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function applyPayments(string $id, array $params = [], array $headers = []): ApplyPaymentsInvoiceResponse;
 
@@ -119,6 +160,13 @@ Interface InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ApplyPaymentScheduleSchemeInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function applyPaymentScheduleScheme(string $id, array $params, array $headers = []): ApplyPaymentScheduleSchemeInvoiceResponse;
 
@@ -131,6 +179,13 @@ Interface InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return VoidInvoiceInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function voidInvoice(string $id, array $params = [], array $headers = []): VoidInvoiceInvoiceResponse;
 
@@ -155,6 +210,13 @@ Interface InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return AddChargeInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function addCharge(string $id, array $params, array $headers = []): AddChargeInvoiceResponse;
 
@@ -164,6 +226,13 @@ Interface InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return SendEinvoiceInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function sendEinvoice(string $id, array $headers = []): SendEinvoiceInvoiceResponse;
 
@@ -173,6 +242,13 @@ Interface InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return PaymentSchedulesInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function paymentSchedules(string $id, array $headers = []): PaymentSchedulesInvoiceResponse;
 
@@ -184,6 +260,13 @@ Interface InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return WriteOffInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function writeOff(string $id, array $params = [], array $headers = []): WriteOffInvoiceResponse;
 
@@ -215,6 +298,13 @@ Interface InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return AddChargeItemInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function addChargeItem(string $id, array $params, array $headers = []): AddChargeItemInvoiceResponse;
 
@@ -227,6 +317,13 @@ Interface InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return PauseDunningInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function pauseDunning(string $id, array $params, array $headers = []): PauseDunningInvoiceResponse;
 
@@ -386,6 +483,13 @@ Interface InvoiceActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListInvoiceResponse;
 
@@ -522,6 +626,13 @@ Interface InvoiceActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params = [], array $headers = []): CreateInvoiceResponse;
 
@@ -540,6 +651,13 @@ Interface InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CloseInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function close(string $id, array $params = [], array $headers = []): CloseInvoiceResponse;
 
@@ -554,6 +672,13 @@ Interface InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ApplyCreditsInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function applyCredits(string $id, array $params = [], array $headers = []): ApplyCreditsInvoiceResponse;
 
@@ -572,6 +697,13 @@ Interface InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $params = [], array $headers = []): RetrieveInvoiceResponse;
 
@@ -608,6 +740,13 @@ Interface InvoiceActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateForChargeItemInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createForChargeItem(array $params, array $headers = []): CreateForChargeItemInvoiceResponse;
 
@@ -762,6 +901,13 @@ Interface InvoiceActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateForChargeItemsAndChargesInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createForChargeItemsAndCharges(array $params, array $headers = []): CreateForChargeItemsAndChargesInvoiceResponse;
 
@@ -811,6 +957,13 @@ Interface InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateDetailsInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function updateDetails(string $id, array $params = [], array $headers = []): UpdateDetailsInvoiceResponse;
 
@@ -823,6 +976,13 @@ Interface InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return InvoicesForCustomerInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function invoicesForCustomer(string $id, array $params = [], array $headers = []): InvoicesForCustomerInvoiceResponse;
 
@@ -845,6 +1005,13 @@ Interface InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RecordPaymentInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function recordPayment(string $id, array $params, array $headers = []): RecordPaymentInvoiceResponse;
 
@@ -856,6 +1023,13 @@ Interface InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $params = [], array $headers = []): DeleteInvoiceResponse;
 
@@ -1023,6 +1197,13 @@ Interface InvoiceActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ImportInvoiceInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function importInvoice(array $params, array $headers = []): ImportInvoiceInvoiceResponse;
 
@@ -1034,6 +1215,13 @@ Interface InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ResumeDunningInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function resumeDunning(string $id, array $params = [], array $headers = []): ResumeDunningInvoiceResponse;
 
@@ -1050,6 +1238,13 @@ Interface InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RecordTaxWithheldInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function recordTaxWithheld(string $id, array $params, array $headers = []): RecordTaxWithheldInvoiceResponse;
 
@@ -1059,6 +1254,13 @@ Interface InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ResendEinvoiceInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function resendEinvoice(string $id, array $headers = []): ResendEinvoiceInvoiceResponse;
 
@@ -1072,6 +1274,13 @@ Interface InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RemoveTaxWithheldInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function removeTaxWithheld(string $id, array $params, array $headers = []): RemoveTaxWithheldInvoiceResponse;
 
@@ -1082,18 +1291,25 @@ Interface InvoiceActionsInterface
     *     offset?: string,
     *     payment_reference_number?: array{
     *     number?: array{
-    *         is?: string,
-    *             in?: string,
+    *         in?: string,
+    *             is?: string,
     *             },
     *     },
     * id?: array{
-    *     is?: mixed,
     *     in?: mixed,
+    *     is?: mixed,
     *     },
     * } $params Description of the parameters
     *   
     *   @param array<string, string> $headers
     *   @return ListPaymentReferenceNumbersInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function listPaymentReferenceNumbers(array $params = [], array $headers = []): ListPaymentReferenceNumbersInvoiceResponse;
 
@@ -1109,6 +1325,13 @@ Interface InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CollectPaymentInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function collectPayment(string $id, array $params = [], array $headers = []): CollectPaymentInvoiceResponse;
 
@@ -1118,6 +1341,13 @@ Interface InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return SyncUsagesInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function syncUsages(string $id, array $headers = []): SyncUsagesInvoiceResponse;
 
@@ -1135,6 +1365,13 @@ Interface InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RefundInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function refund(string $id, array $params = [], array $headers = []): RefundInvoiceResponse;
 
@@ -1158,6 +1395,13 @@ Interface InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RecordRefundInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function recordRefund(string $id, array $params, array $headers = []): RecordRefundInvoiceResponse;
 
@@ -1169,6 +1413,13 @@ Interface InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return PdfInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function pdf(string $id, array $params = [], array $headers = []): PdfInvoiceResponse;
 
@@ -1181,6 +1432,13 @@ Interface InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return InvoicesForSubscriptionInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function invoicesForSubscription(string $id, array $params = [], array $headers = []): InvoicesForSubscriptionInvoiceResponse;
 
@@ -1190,6 +1448,13 @@ Interface InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DownloadEinvoiceInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function downloadEinvoice(string $id, array $headers = []): DownloadEinvoiceInvoiceResponse;
 
@@ -1215,6 +1480,13 @@ Interface InvoiceActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ChargeAddonInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function chargeAddon(array $params, array $headers = []): ChargeAddonInvoiceResponse;
 
@@ -1236,6 +1508,13 @@ Interface InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return AddAddonChargeInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function addAddonCharge(string $id, array $params, array $headers = []): AddAddonChargeInvoiceResponse;
 
@@ -1268,6 +1547,13 @@ Interface InvoiceActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ChargeInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function charge(array $params, array $headers = []): ChargeInvoiceResponse;
 

--- a/src/Actions/Contracts/InvoiceActionsInterface.php
+++ b/src/Actions/Contracts/InvoiceActionsInterface.php
@@ -42,7 +42,6 @@ use Chargebee\Responses\InvoiceResponse\RemoveCreditNoteInvoiceResponse;
 use Chargebee\Responses\InvoiceResponse\ImportInvoiceInvoiceResponse;
 use Chargebee\Responses\InvoiceResponse\RefundInvoiceResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -62,12 +61,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteLineItemsInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function deleteLineItems(string $id, array $params = [], array $headers = []): DeleteLineItemsInvoiceResponse;
 
@@ -82,12 +79,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return RemoveCreditNoteInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function removeCreditNote(string $id, array $params, array $headers = []): RemoveCreditNoteInvoiceResponse;
 
@@ -102,12 +97,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return RemovePaymentInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function removePayment(string $id, array $params, array $headers = []): RemovePaymentInvoiceResponse;
 
@@ -120,12 +113,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return StopDunningInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function stopDunning(string $id, array $params = [], array $headers = []): StopDunningInvoiceResponse;
 
@@ -142,12 +133,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return ApplyPaymentsInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function applyPayments(string $id, array $params = [], array $headers = []): ApplyPaymentsInvoiceResponse;
 
@@ -161,12 +150,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return ApplyPaymentScheduleSchemeInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function applyPaymentScheduleScheme(string $id, array $params, array $headers = []): ApplyPaymentScheduleSchemeInvoiceResponse;
 
@@ -180,12 +167,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return VoidInvoiceInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function voidInvoice(string $id, array $params = [], array $headers = []): VoidInvoiceInvoiceResponse;
 
@@ -211,12 +196,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return AddChargeInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function addCharge(string $id, array $params, array $headers = []): AddChargeInvoiceResponse;
 
@@ -227,12 +210,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return SendEinvoiceInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function sendEinvoice(string $id, array $headers = []): SendEinvoiceInvoiceResponse;
 
@@ -243,12 +224,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return PaymentSchedulesInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function paymentSchedules(string $id, array $headers = []): PaymentSchedulesInvoiceResponse;
 
@@ -261,12 +240,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return WriteOffInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function writeOff(string $id, array $params = [], array $headers = []): WriteOffInvoiceResponse;
 
@@ -299,12 +276,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return AddChargeItemInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function addChargeItem(string $id, array $params, array $headers = []): AddChargeItemInvoiceResponse;
 
@@ -318,12 +293,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return PauseDunningInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function pauseDunning(string $id, array $params, array $headers = []): PauseDunningInvoiceResponse;
 
@@ -484,12 +457,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return ListInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListInvoiceResponse;
 
@@ -627,12 +598,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params = [], array $headers = []): CreateInvoiceResponse;
 
@@ -652,12 +621,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return CloseInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function close(string $id, array $params = [], array $headers = []): CloseInvoiceResponse;
 
@@ -673,12 +640,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return ApplyCreditsInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function applyCredits(string $id, array $params = [], array $headers = []): ApplyCreditsInvoiceResponse;
 
@@ -698,12 +663,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $params = [], array $headers = []): RetrieveInvoiceResponse;
 
@@ -741,12 +704,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateForChargeItemInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createForChargeItem(array $params, array $headers = []): CreateForChargeItemInvoiceResponse;
 
@@ -902,12 +863,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateForChargeItemsAndChargesInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createForChargeItemsAndCharges(array $params, array $headers = []): CreateForChargeItemsAndChargesInvoiceResponse;
 
@@ -958,12 +917,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateDetailsInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function updateDetails(string $id, array $params = [], array $headers = []): UpdateDetailsInvoiceResponse;
 
@@ -977,12 +934,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return InvoicesForCustomerInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function invoicesForCustomer(string $id, array $params = [], array $headers = []): InvoicesForCustomerInvoiceResponse;
 
@@ -1006,12 +961,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return RecordPaymentInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function recordPayment(string $id, array $params, array $headers = []): RecordPaymentInvoiceResponse;
 
@@ -1024,12 +977,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $params = [], array $headers = []): DeleteInvoiceResponse;
 
@@ -1198,12 +1149,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return ImportInvoiceInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function importInvoice(array $params, array $headers = []): ImportInvoiceInvoiceResponse;
 
@@ -1216,12 +1165,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return ResumeDunningInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function resumeDunning(string $id, array $params = [], array $headers = []): ResumeDunningInvoiceResponse;
 
@@ -1239,12 +1186,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return RecordTaxWithheldInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function recordTaxWithheld(string $id, array $params, array $headers = []): RecordTaxWithheldInvoiceResponse;
 
@@ -1255,12 +1200,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return ResendEinvoiceInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function resendEinvoice(string $id, array $headers = []): ResendEinvoiceInvoiceResponse;
 
@@ -1275,12 +1218,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return RemoveTaxWithheldInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function removeTaxWithheld(string $id, array $params, array $headers = []): RemoveTaxWithheldInvoiceResponse;
 
@@ -1304,12 +1245,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return ListPaymentReferenceNumbersInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function listPaymentReferenceNumbers(array $params = [], array $headers = []): ListPaymentReferenceNumbersInvoiceResponse;
 
@@ -1326,12 +1265,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return CollectPaymentInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function collectPayment(string $id, array $params = [], array $headers = []): CollectPaymentInvoiceResponse;
 
@@ -1342,12 +1279,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return SyncUsagesInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function syncUsages(string $id, array $headers = []): SyncUsagesInvoiceResponse;
 
@@ -1366,12 +1301,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return RefundInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function refund(string $id, array $params = [], array $headers = []): RefundInvoiceResponse;
 
@@ -1396,12 +1329,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return RecordRefundInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function recordRefund(string $id, array $params, array $headers = []): RecordRefundInvoiceResponse;
 
@@ -1414,12 +1345,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return PdfInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function pdf(string $id, array $params = [], array $headers = []): PdfInvoiceResponse;
 
@@ -1433,12 +1362,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return InvoicesForSubscriptionInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function invoicesForSubscription(string $id, array $params = [], array $headers = []): InvoicesForSubscriptionInvoiceResponse;
 
@@ -1449,12 +1376,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return DownloadEinvoiceInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function downloadEinvoice(string $id, array $headers = []): DownloadEinvoiceInvoiceResponse;
 
@@ -1481,12 +1406,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return ChargeAddonInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function chargeAddon(array $params, array $headers = []): ChargeAddonInvoiceResponse;
 
@@ -1509,12 +1432,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return AddAddonChargeInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function addAddonCharge(string $id, array $params, array $headers = []): AddAddonChargeInvoiceResponse;
 
@@ -1548,12 +1469,10 @@ Interface InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return ChargeInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function charge(array $params, array $headers = []): ChargeInvoiceResponse;
 

--- a/src/Actions/Contracts/ItemActionsInterface.php
+++ b/src/Actions/Contracts/ItemActionsInterface.php
@@ -7,7 +7,6 @@ use Chargebee\Responses\ItemResponse\CreateItemResponse;
 use Chargebee\Responses\ItemResponse\RetrieveItemResponse;
 use Chargebee\Responses\ItemResponse\ListItemResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -112,12 +111,10 @@ Interface ItemActionsInterface
     *   @param array<string, string> $headers
     *   @return ListItemResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListItemResponse;
 
@@ -159,12 +156,10 @@ Interface ItemActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateItemResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateItemResponse;
 
@@ -175,12 +170,10 @@ Interface ItemActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteItemResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteItemResponse;
 
@@ -191,12 +184,10 @@ Interface ItemActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveItemResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveItemResponse;
 
@@ -244,12 +235,10 @@ Interface ItemActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateItemResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdateItemResponse;
 

--- a/src/Actions/Contracts/ItemActionsInterface.php
+++ b/src/Actions/Contracts/ItemActionsInterface.php
@@ -6,6 +6,12 @@ use Chargebee\Responses\ItemResponse\UpdateItemResponse;
 use Chargebee\Responses\ItemResponse\CreateItemResponse;
 use Chargebee\Responses\ItemResponse\RetrieveItemResponse;
 use Chargebee\Responses\ItemResponse\ListItemResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface ItemActionsInterface
 {
@@ -105,6 +111,13 @@ Interface ItemActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListItemResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListItemResponse;
 
@@ -145,6 +158,13 @@ Interface ItemActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateItemResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateItemResponse;
 
@@ -154,6 +174,13 @@ Interface ItemActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteItemResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteItemResponse;
 
@@ -163,6 +190,13 @@ Interface ItemActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveItemResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveItemResponse;
 
@@ -209,6 +243,13 @@ Interface ItemActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateItemResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdateItemResponse;
 

--- a/src/Actions/Contracts/ItemEntitlementActionsInterface.php
+++ b/src/Actions/Contracts/ItemEntitlementActionsInterface.php
@@ -6,7 +6,6 @@ use Chargebee\Responses\ItemEntitlementResponse\UpsertOrRemoveItemEntitlementsFo
 use Chargebee\Responses\ItemEntitlementResponse\AddItemEntitlementsItemEntitlementResponse;
 use Chargebee\Responses\ItemEntitlementResponse\ItemEntitlementsForFeatureItemEntitlementResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -26,12 +25,10 @@ Interface ItemEntitlementActionsInterface
     *   @param array<string, string> $headers
     *   @return ItemEntitlementsForFeatureItemEntitlementResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function itemEntitlementsForFeature(string $id, array $params = [], array $headers = []): ItemEntitlementsForFeatureItemEntitlementResponse;
 
@@ -49,12 +46,10 @@ Interface ItemEntitlementActionsInterface
     *   @param array<string, string> $headers
     *   @return AddItemEntitlementsItemEntitlementResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function addItemEntitlements(string $id, array $params, array $headers = []): AddItemEntitlementsItemEntitlementResponse;
 
@@ -70,12 +65,10 @@ Interface ItemEntitlementActionsInterface
     *   @param array<string, string> $headers
     *   @return ItemEntitlementsForItemItemEntitlementResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function itemEntitlementsForItem(string $id, array $params = [], array $headers = []): ItemEntitlementsForItemItemEntitlementResponse;
 
@@ -92,12 +85,10 @@ Interface ItemEntitlementActionsInterface
     *   @param array<string, string> $headers
     *   @return UpsertOrRemoveItemEntitlementsForItemItemEntitlementResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function upsertOrRemoveItemEntitlementsForItem(string $id, array $params, array $headers = []): UpsertOrRemoveItemEntitlementsForItemItemEntitlementResponse;
 

--- a/src/Actions/Contracts/ItemEntitlementActionsInterface.php
+++ b/src/Actions/Contracts/ItemEntitlementActionsInterface.php
@@ -5,6 +5,12 @@ use Chargebee\Responses\ItemEntitlementResponse\ItemEntitlementsForItemItemEntit
 use Chargebee\Responses\ItemEntitlementResponse\UpsertOrRemoveItemEntitlementsForItemItemEntitlementResponse;
 use Chargebee\Responses\ItemEntitlementResponse\AddItemEntitlementsItemEntitlementResponse;
 use Chargebee\Responses\ItemEntitlementResponse\ItemEntitlementsForFeatureItemEntitlementResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface ItemEntitlementActionsInterface
 {
@@ -19,6 +25,13 @@ Interface ItemEntitlementActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ItemEntitlementsForFeatureItemEntitlementResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function itemEntitlementsForFeature(string $id, array $params = [], array $headers = []): ItemEntitlementsForFeatureItemEntitlementResponse;
 
@@ -35,6 +48,13 @@ Interface ItemEntitlementActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return AddItemEntitlementsItemEntitlementResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function addItemEntitlements(string $id, array $params, array $headers = []): AddItemEntitlementsItemEntitlementResponse;
 
@@ -49,6 +69,13 @@ Interface ItemEntitlementActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ItemEntitlementsForItemItemEntitlementResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function itemEntitlementsForItem(string $id, array $params = [], array $headers = []): ItemEntitlementsForItemItemEntitlementResponse;
 
@@ -64,6 +91,13 @@ Interface ItemEntitlementActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpsertOrRemoveItemEntitlementsForItemItemEntitlementResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function upsertOrRemoveItemEntitlementsForItem(string $id, array $params, array $headers = []): UpsertOrRemoveItemEntitlementsForItemItemEntitlementResponse;
 

--- a/src/Actions/Contracts/ItemFamilyActionsInterface.php
+++ b/src/Actions/Contracts/ItemFamilyActionsInterface.php
@@ -6,6 +6,12 @@ use Chargebee\Responses\ItemFamilyResponse\ListItemFamilyResponse;
 use Chargebee\Responses\ItemFamilyResponse\CreateItemFamilyResponse;
 use Chargebee\Responses\ItemFamilyResponse\DeleteItemFamilyResponse;
 use Chargebee\Responses\ItemFamilyResponse\UpdateItemFamilyResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface ItemFamilyActionsInterface
 {
@@ -16,6 +22,13 @@ Interface ItemFamilyActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteItemFamilyResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteItemFamilyResponse;
 
@@ -53,6 +66,13 @@ Interface ItemFamilyActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListItemFamilyResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListItemFamilyResponse;
 
@@ -67,6 +87,13 @@ Interface ItemFamilyActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateItemFamilyResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateItemFamilyResponse;
 
@@ -76,6 +103,13 @@ Interface ItemFamilyActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveItemFamilyResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveItemFamilyResponse;
 
@@ -88,6 +122,13 @@ Interface ItemFamilyActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateItemFamilyResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdateItemFamilyResponse;
 

--- a/src/Actions/Contracts/ItemFamilyActionsInterface.php
+++ b/src/Actions/Contracts/ItemFamilyActionsInterface.php
@@ -7,7 +7,6 @@ use Chargebee\Responses\ItemFamilyResponse\CreateItemFamilyResponse;
 use Chargebee\Responses\ItemFamilyResponse\DeleteItemFamilyResponse;
 use Chargebee\Responses\ItemFamilyResponse\UpdateItemFamilyResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -23,12 +22,10 @@ Interface ItemFamilyActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteItemFamilyResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteItemFamilyResponse;
 
@@ -67,12 +64,10 @@ Interface ItemFamilyActionsInterface
     *   @param array<string, string> $headers
     *   @return ListItemFamilyResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListItemFamilyResponse;
 
@@ -88,12 +83,10 @@ Interface ItemFamilyActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateItemFamilyResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateItemFamilyResponse;
 
@@ -104,12 +97,10 @@ Interface ItemFamilyActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveItemFamilyResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveItemFamilyResponse;
 
@@ -123,12 +114,10 @@ Interface ItemFamilyActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateItemFamilyResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdateItemFamilyResponse;
 

--- a/src/Actions/Contracts/ItemPriceActionsInterface.php
+++ b/src/Actions/Contracts/ItemPriceActionsInterface.php
@@ -9,7 +9,6 @@ use Chargebee\Responses\ItemPriceResponse\RetrieveItemPriceResponse;
 use Chargebee\Responses\ItemPriceResponse\FindApplicableItemPricesItemPriceResponse;
 use Chargebee\Responses\ItemPriceResponse\ListItemPriceResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -32,12 +31,10 @@ Interface ItemPriceActionsInterface
     *   @param array<string, string> $headers
     *   @return FindApplicableItemsItemPriceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function findApplicableItems(string $id, array $params = [], array $headers = []): FindApplicableItemsItemPriceResponse;
 
@@ -48,12 +45,10 @@ Interface ItemPriceActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveItemPriceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveItemPriceResponse;
 
@@ -123,12 +118,10 @@ Interface ItemPriceActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateItemPriceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params, array $headers = []): UpdateItemPriceResponse;
 
@@ -139,12 +132,10 @@ Interface ItemPriceActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteItemPriceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteItemPriceResponse;
 
@@ -163,12 +154,10 @@ Interface ItemPriceActionsInterface
     *   @param array<string, string> $headers
     *   @return FindApplicableItemPricesItemPriceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function findApplicableItemPrices(string $id, array $params = [], array $headers = []): FindApplicableItemPricesItemPriceResponse;
 
@@ -295,12 +284,10 @@ Interface ItemPriceActionsInterface
     *   @param array<string, string> $headers
     *   @return ListItemPriceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListItemPriceResponse;
 
@@ -372,12 +359,10 @@ Interface ItemPriceActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateItemPriceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateItemPriceResponse;
 

--- a/src/Actions/Contracts/ItemPriceActionsInterface.php
+++ b/src/Actions/Contracts/ItemPriceActionsInterface.php
@@ -8,6 +8,12 @@ use Chargebee\Responses\ItemPriceResponse\UpdateItemPriceResponse;
 use Chargebee\Responses\ItemPriceResponse\RetrieveItemPriceResponse;
 use Chargebee\Responses\ItemPriceResponse\FindApplicableItemPricesItemPriceResponse;
 use Chargebee\Responses\ItemPriceResponse\ListItemPriceResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface ItemPriceActionsInterface
 {
@@ -25,6 +31,13 @@ Interface ItemPriceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return FindApplicableItemsItemPriceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function findApplicableItems(string $id, array $params = [], array $headers = []): FindApplicableItemsItemPriceResponse;
 
@@ -34,6 +47,13 @@ Interface ItemPriceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveItemPriceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveItemPriceResponse;
 
@@ -102,6 +122,13 @@ Interface ItemPriceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateItemPriceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params, array $headers = []): UpdateItemPriceResponse;
 
@@ -111,6 +138,13 @@ Interface ItemPriceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteItemPriceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteItemPriceResponse;
 
@@ -128,6 +162,13 @@ Interface ItemPriceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return FindApplicableItemPricesItemPriceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function findApplicableItemPrices(string $id, array $params = [], array $headers = []): FindApplicableItemPricesItemPriceResponse;
 
@@ -253,6 +294,13 @@ Interface ItemPriceActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListItemPriceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListItemPriceResponse;
 
@@ -323,6 +371,13 @@ Interface ItemPriceActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateItemPriceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateItemPriceResponse;
 

--- a/src/Actions/Contracts/NonSubscriptionActionsInterface.php
+++ b/src/Actions/Contracts/NonSubscriptionActionsInterface.php
@@ -3,7 +3,6 @@ namespace Chargebee\Actions\Contracts;
     
 use Chargebee\Responses\NonSubscriptionResponse\ProcessReceiptNonSubscriptionResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -35,12 +34,10 @@ Interface NonSubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return ProcessReceiptNonSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function processReceipt(string $id, array $params, array $headers = []): ProcessReceiptNonSubscriptionResponse;
 

--- a/src/Actions/Contracts/NonSubscriptionActionsInterface.php
+++ b/src/Actions/Contracts/NonSubscriptionActionsInterface.php
@@ -2,6 +2,12 @@
 namespace Chargebee\Actions\Contracts;
     
 use Chargebee\Responses\NonSubscriptionResponse\ProcessReceiptNonSubscriptionResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface NonSubscriptionActionsInterface
 {
@@ -28,6 +34,13 @@ Interface NonSubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ProcessReceiptNonSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function processReceipt(string $id, array $params, array $headers = []): ProcessReceiptNonSubscriptionResponse;
 

--- a/src/Actions/Contracts/OmnichannelOneTimeOrderActionsInterface.php
+++ b/src/Actions/Contracts/OmnichannelOneTimeOrderActionsInterface.php
@@ -4,7 +4,6 @@ namespace Chargebee\Actions\Contracts;
 use Chargebee\Responses\OmnichannelOneTimeOrderResponse\RetrieveOmnichannelOneTimeOrderResponse;
 use Chargebee\Responses\OmnichannelOneTimeOrderResponse\ListOmnichannelOneTimeOrderResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -34,12 +33,10 @@ Interface OmnichannelOneTimeOrderActionsInterface
     *   @param array<string, string> $headers
     *   @return ListOmnichannelOneTimeOrderResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListOmnichannelOneTimeOrderResponse;
 
@@ -50,12 +47,10 @@ Interface OmnichannelOneTimeOrderActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveOmnichannelOneTimeOrderResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveOmnichannelOneTimeOrderResponse;
 

--- a/src/Actions/Contracts/OmnichannelOneTimeOrderActionsInterface.php
+++ b/src/Actions/Contracts/OmnichannelOneTimeOrderActionsInterface.php
@@ -3,6 +3,12 @@ namespace Chargebee\Actions\Contracts;
     
 use Chargebee\Responses\OmnichannelOneTimeOrderResponse\RetrieveOmnichannelOneTimeOrderResponse;
 use Chargebee\Responses\OmnichannelOneTimeOrderResponse\ListOmnichannelOneTimeOrderResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface OmnichannelOneTimeOrderActionsInterface
 {
@@ -27,6 +33,13 @@ Interface OmnichannelOneTimeOrderActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListOmnichannelOneTimeOrderResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListOmnichannelOneTimeOrderResponse;
 
@@ -36,6 +49,13 @@ Interface OmnichannelOneTimeOrderActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveOmnichannelOneTimeOrderResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveOmnichannelOneTimeOrderResponse;
 

--- a/src/Actions/Contracts/OmnichannelSubscriptionActionsInterface.php
+++ b/src/Actions/Contracts/OmnichannelSubscriptionActionsInterface.php
@@ -4,6 +4,12 @@ namespace Chargebee\Actions\Contracts;
 use Chargebee\Responses\OmnichannelSubscriptionResponse\RetrieveOmnichannelSubscriptionResponse;
 use Chargebee\Responses\OmnichannelSubscriptionResponse\OmnichannelTransactionsForOmnichannelSubscriptionOmnichannelSubscriptionResponse;
 use Chargebee\Responses\OmnichannelSubscriptionResponse\ListOmnichannelSubscriptionResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface OmnichannelSubscriptionActionsInterface
 {
@@ -14,6 +20,13 @@ Interface OmnichannelSubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveOmnichannelSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveOmnichannelSubscriptionResponse;
 
@@ -26,6 +39,13 @@ Interface OmnichannelSubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return OmnichannelTransactionsForOmnichannelSubscriptionOmnichannelSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function omnichannelTransactionsForOmnichannelSubscription(string $id, array $params = [], array $headers = []): OmnichannelTransactionsForOmnichannelSubscriptionOmnichannelSubscriptionResponse;
 
@@ -49,6 +69,13 @@ Interface OmnichannelSubscriptionActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListOmnichannelSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListOmnichannelSubscriptionResponse;
 

--- a/src/Actions/Contracts/OmnichannelSubscriptionActionsInterface.php
+++ b/src/Actions/Contracts/OmnichannelSubscriptionActionsInterface.php
@@ -5,7 +5,6 @@ use Chargebee\Responses\OmnichannelSubscriptionResponse\RetrieveOmnichannelSubsc
 use Chargebee\Responses\OmnichannelSubscriptionResponse\OmnichannelTransactionsForOmnichannelSubscriptionOmnichannelSubscriptionResponse;
 use Chargebee\Responses\OmnichannelSubscriptionResponse\ListOmnichannelSubscriptionResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -21,12 +20,10 @@ Interface OmnichannelSubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveOmnichannelSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveOmnichannelSubscriptionResponse;
 
@@ -40,12 +37,10 @@ Interface OmnichannelSubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return OmnichannelTransactionsForOmnichannelSubscriptionOmnichannelSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function omnichannelTransactionsForOmnichannelSubscription(string $id, array $params = [], array $headers = []): OmnichannelTransactionsForOmnichannelSubscriptionOmnichannelSubscriptionResponse;
 
@@ -70,12 +65,10 @@ Interface OmnichannelSubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return ListOmnichannelSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListOmnichannelSubscriptionResponse;
 

--- a/src/Actions/Contracts/OmnichannelSubscriptionItemActionsInterface.php
+++ b/src/Actions/Contracts/OmnichannelSubscriptionItemActionsInterface.php
@@ -2,6 +2,12 @@
 namespace Chargebee\Actions\Contracts;
     
 use Chargebee\Responses\OmnichannelSubscriptionItemResponse\ListOmniSubItemScheduleChangesOmnichannelSubscriptionItemResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface OmnichannelSubscriptionItemActionsInterface
 {
@@ -15,6 +21,13 @@ Interface OmnichannelSubscriptionItemActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ListOmniSubItemScheduleChangesOmnichannelSubscriptionItemResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function listOmniSubItemScheduleChanges(string $id, array $params = [], array $headers = []): ListOmniSubItemScheduleChangesOmnichannelSubscriptionItemResponse;
 

--- a/src/Actions/Contracts/OmnichannelSubscriptionItemActionsInterface.php
+++ b/src/Actions/Contracts/OmnichannelSubscriptionItemActionsInterface.php
@@ -3,7 +3,6 @@ namespace Chargebee\Actions\Contracts;
     
 use Chargebee\Responses\OmnichannelSubscriptionItemResponse\ListOmniSubItemScheduleChangesOmnichannelSubscriptionItemResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -22,12 +21,10 @@ Interface OmnichannelSubscriptionItemActionsInterface
     *   @param array<string, string> $headers
     *   @return ListOmniSubItemScheduleChangesOmnichannelSubscriptionItemResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function listOmniSubItemScheduleChanges(string $id, array $params = [], array $headers = []): ListOmniSubItemScheduleChangesOmnichannelSubscriptionItemResponse;
 

--- a/src/Actions/Contracts/OrderActionsInterface.php
+++ b/src/Actions/Contracts/OrderActionsInterface.php
@@ -14,7 +14,6 @@ use Chargebee\Responses\OrderResponse\ListOrderResponse;
 use Chargebee\Responses\OrderResponse\AssignOrderNumberOrderResponse;
 use Chargebee\Responses\OrderResponse\DeleteOrderResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -120,12 +119,10 @@ Interface OrderActionsInterface
     *   @param array<string, string> $headers
     *   @return ListOrderResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListOrderResponse;
 
@@ -146,12 +143,10 @@ Interface OrderActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateOrderResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateOrderResponse;
 
@@ -217,12 +212,10 @@ Interface OrderActionsInterface
     *   @param array<string, string> $headers
     *   @return ImportOrderOrderResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function importOrder(array $params, array $headers = []): ImportOrderOrderResponse;
 
@@ -233,12 +226,10 @@ Interface OrderActionsInterface
     *   @param array<string, string> $headers
     *   @return AssignOrderNumberOrderResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function assignOrderNumber(string $id, array $headers = []): AssignOrderNumberOrderResponse;
 
@@ -256,12 +247,10 @@ Interface OrderActionsInterface
     *   @param array<string, string> $headers
     *   @return ResendOrderResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function resend(string $id, array $params = [], array $headers = []): ResendOrderResponse;
 
@@ -274,12 +263,10 @@ Interface OrderActionsInterface
     *   @param array<string, string> $headers
     *   @return ReopenOrderResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function reopen(string $id, array $params = [], array $headers = []): ReopenOrderResponse;
 
@@ -293,12 +280,10 @@ Interface OrderActionsInterface
     *   @param array<string, string> $headers
     *   @return OrdersForInvoiceOrderResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function ordersForInvoice(string $id, array $params = [], array $headers = []): OrdersForInvoiceOrderResponse;
 
@@ -317,12 +302,10 @@ Interface OrderActionsInterface
     *   @param array<string, string> $headers
     *   @return CancelOrderResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function cancel(string $id, array $params, array $headers = []): CancelOrderResponse;
 
@@ -333,12 +316,10 @@ Interface OrderActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveOrderResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveOrderResponse;
 
@@ -385,12 +366,10 @@ Interface OrderActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateOrderResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdateOrderResponse;
 
@@ -401,12 +380,10 @@ Interface OrderActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteOrderResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteOrderResponse;
 
@@ -424,12 +401,10 @@ Interface OrderActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateRefundableCreditNoteOrderResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createRefundableCreditNote(string $id, array $params, array $headers = []): CreateRefundableCreditNoteOrderResponse;
 

--- a/src/Actions/Contracts/OrderActionsInterface.php
+++ b/src/Actions/Contracts/OrderActionsInterface.php
@@ -13,6 +13,12 @@ use Chargebee\Responses\OrderResponse\CreateOrderResponse;
 use Chargebee\Responses\OrderResponse\ListOrderResponse;
 use Chargebee\Responses\OrderResponse\AssignOrderNumberOrderResponse;
 use Chargebee\Responses\OrderResponse\DeleteOrderResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface OrderActionsInterface
 {
@@ -113,6 +119,13 @@ Interface OrderActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListOrderResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListOrderResponse;
 
@@ -132,6 +145,13 @@ Interface OrderActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateOrderResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateOrderResponse;
 
@@ -196,6 +216,13 @@ Interface OrderActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ImportOrderOrderResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function importOrder(array $params, array $headers = []): ImportOrderOrderResponse;
 
@@ -205,6 +232,13 @@ Interface OrderActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return AssignOrderNumberOrderResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function assignOrderNumber(string $id, array $headers = []): AssignOrderNumberOrderResponse;
 
@@ -221,6 +255,13 @@ Interface OrderActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ResendOrderResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function resend(string $id, array $params = [], array $headers = []): ResendOrderResponse;
 
@@ -232,6 +273,13 @@ Interface OrderActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ReopenOrderResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function reopen(string $id, array $params = [], array $headers = []): ReopenOrderResponse;
 
@@ -244,6 +292,13 @@ Interface OrderActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return OrdersForInvoiceOrderResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function ordersForInvoice(string $id, array $params = [], array $headers = []): OrdersForInvoiceOrderResponse;
 
@@ -261,6 +316,13 @@ Interface OrderActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CancelOrderResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function cancel(string $id, array $params, array $headers = []): CancelOrderResponse;
 
@@ -270,6 +332,13 @@ Interface OrderActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveOrderResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveOrderResponse;
 
@@ -315,6 +384,13 @@ Interface OrderActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateOrderResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdateOrderResponse;
 
@@ -324,6 +400,13 @@ Interface OrderActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteOrderResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteOrderResponse;
 
@@ -340,6 +423,13 @@ Interface OrderActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CreateRefundableCreditNoteOrderResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createRefundableCreditNote(string $id, array $params, array $headers = []): CreateRefundableCreditNoteOrderResponse;
 

--- a/src/Actions/Contracts/PaymentIntentActionsInterface.php
+++ b/src/Actions/Contracts/PaymentIntentActionsInterface.php
@@ -4,6 +4,12 @@ namespace Chargebee\Actions\Contracts;
 use Chargebee\Responses\PaymentIntentResponse\UpdatePaymentIntentResponse;
 use Chargebee\Responses\PaymentIntentResponse\RetrievePaymentIntentResponse;
 use Chargebee\Responses\PaymentIntentResponse\CreatePaymentIntentResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface PaymentIntentActionsInterface
 {
@@ -14,6 +20,13 @@ Interface PaymentIntentActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrievePaymentIntentResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrievePaymentIntentResponse;
 
@@ -30,6 +43,13 @@ Interface PaymentIntentActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdatePaymentIntentResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdatePaymentIntentResponse;
 
@@ -49,6 +69,13 @@ Interface PaymentIntentActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreatePaymentIntentResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreatePaymentIntentResponse;
 

--- a/src/Actions/Contracts/PaymentIntentActionsInterface.php
+++ b/src/Actions/Contracts/PaymentIntentActionsInterface.php
@@ -5,7 +5,6 @@ use Chargebee\Responses\PaymentIntentResponse\UpdatePaymentIntentResponse;
 use Chargebee\Responses\PaymentIntentResponse\RetrievePaymentIntentResponse;
 use Chargebee\Responses\PaymentIntentResponse\CreatePaymentIntentResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -21,12 +20,10 @@ Interface PaymentIntentActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrievePaymentIntentResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrievePaymentIntentResponse;
 
@@ -44,12 +41,10 @@ Interface PaymentIntentActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdatePaymentIntentResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdatePaymentIntentResponse;
 
@@ -70,12 +65,10 @@ Interface PaymentIntentActionsInterface
     *   @param array<string, string> $headers
     *   @return CreatePaymentIntentResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreatePaymentIntentResponse;
 

--- a/src/Actions/Contracts/PaymentScheduleSchemeActionsInterface.php
+++ b/src/Actions/Contracts/PaymentScheduleSchemeActionsInterface.php
@@ -5,7 +5,6 @@ use Chargebee\Responses\PaymentScheduleSchemeResponse\DeletePaymentScheduleSchem
 use Chargebee\Responses\PaymentScheduleSchemeResponse\RetrievePaymentScheduleSchemeResponse;
 use Chargebee\Responses\PaymentScheduleSchemeResponse\CreatePaymentScheduleSchemeResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -21,12 +20,10 @@ Interface PaymentScheduleSchemeActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrievePaymentScheduleSchemeResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrievePaymentScheduleSchemeResponse;
 
@@ -46,12 +43,10 @@ Interface PaymentScheduleSchemeActionsInterface
     *   @param array<string, string> $headers
     *   @return CreatePaymentScheduleSchemeResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreatePaymentScheduleSchemeResponse;
 
@@ -62,12 +57,10 @@ Interface PaymentScheduleSchemeActionsInterface
     *   @param array<string, string> $headers
     *   @return DeletePaymentScheduleSchemeResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeletePaymentScheduleSchemeResponse;
 

--- a/src/Actions/Contracts/PaymentScheduleSchemeActionsInterface.php
+++ b/src/Actions/Contracts/PaymentScheduleSchemeActionsInterface.php
@@ -4,6 +4,12 @@ namespace Chargebee\Actions\Contracts;
 use Chargebee\Responses\PaymentScheduleSchemeResponse\DeletePaymentScheduleSchemeResponse;
 use Chargebee\Responses\PaymentScheduleSchemeResponse\RetrievePaymentScheduleSchemeResponse;
 use Chargebee\Responses\PaymentScheduleSchemeResponse\CreatePaymentScheduleSchemeResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface PaymentScheduleSchemeActionsInterface
 {
@@ -14,6 +20,13 @@ Interface PaymentScheduleSchemeActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrievePaymentScheduleSchemeResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrievePaymentScheduleSchemeResponse;
 
@@ -32,6 +45,13 @@ Interface PaymentScheduleSchemeActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreatePaymentScheduleSchemeResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreatePaymentScheduleSchemeResponse;
 
@@ -41,6 +61,13 @@ Interface PaymentScheduleSchemeActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeletePaymentScheduleSchemeResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeletePaymentScheduleSchemeResponse;
 

--- a/src/Actions/Contracts/PaymentSourceActionsInterface.php
+++ b/src/Actions/Contracts/PaymentSourceActionsInterface.php
@@ -17,6 +17,12 @@ use Chargebee\Responses\PaymentSourceResponse\ExportPaymentSourcePaymentSourceRe
 use Chargebee\Responses\PaymentSourceResponse\CreateUsingPaymentIntentPaymentSourceResponse;
 use Chargebee\Responses\PaymentSourceResponse\VerifyBankAccountPaymentSourceResponse;
 use Chargebee\Responses\PaymentSourceResponse\CreateVoucherPaymentSourcePaymentSourceResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface PaymentSourceActionsInterface
 {
@@ -61,6 +67,13 @@ Interface PaymentSourceActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateUsingPermanentTokenPaymentSourceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createUsingPermanentToken(array $params, array $headers = []): CreateUsingPermanentTokenPaymentSourceResponse;
 
@@ -70,6 +83,13 @@ Interface PaymentSourceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeletePaymentSourceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeletePaymentSourceResponse;
 
@@ -100,6 +120,13 @@ Interface PaymentSourceActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateCardPaymentSourceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createCard(array $params, array $headers = []): CreateCardPaymentSourceResponse;
 
@@ -112,6 +139,13 @@ Interface PaymentSourceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return VerifyBankAccountPaymentSourceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function verifyBankAccount(string $id, array $params, array $headers = []): VerifyBankAccountPaymentSourceResponse;
 
@@ -161,6 +195,13 @@ Interface PaymentSourceActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListPaymentSourceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListPaymentSourceResponse;
 
@@ -172,6 +213,13 @@ Interface PaymentSourceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ExportPaymentSourcePaymentSourceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function exportPaymentSource(string $id, array $params, array $headers = []): ExportPaymentSourcePaymentSourceResponse;
 
@@ -194,6 +242,13 @@ Interface PaymentSourceActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateUsingPaymentIntentPaymentSourceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createUsingPaymentIntent(array $params, array $headers = []): CreateUsingPaymentIntentPaymentSourceResponse;
 
@@ -203,6 +258,13 @@ Interface PaymentSourceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrievePaymentSourceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrievePaymentSourceResponse;
 
@@ -220,6 +282,13 @@ Interface PaymentSourceActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateVoucherPaymentSourcePaymentSourceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createVoucherPaymentSource(array $params, array $headers = []): CreateVoucherPaymentSourcePaymentSourceResponse;
 
@@ -237,6 +306,13 @@ Interface PaymentSourceActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateUsingTempTokenPaymentSourceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createUsingTempToken(array $params, array $headers = []): CreateUsingTempTokenPaymentSourceResponse;
 
@@ -263,6 +339,13 @@ Interface PaymentSourceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateCardPaymentSourceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function updateCard(string $id, array $params = [], array $headers = []): UpdateCardPaymentSourceResponse;
 
@@ -274,6 +357,13 @@ Interface PaymentSourceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return SwitchGatewayAccountPaymentSourceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function switchGatewayAccount(string $id, array $params, array $headers = []): SwitchGatewayAccountPaymentSourceResponse;
 
@@ -287,6 +377,13 @@ Interface PaymentSourceActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateUsingTokenPaymentSourceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createUsingToken(array $params, array $headers = []): CreateUsingTokenPaymentSourceResponse;
 
@@ -296,6 +393,13 @@ Interface PaymentSourceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteLocalPaymentSourceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function deleteLocal(string $id, array $headers = []): DeleteLocalPaymentSourceResponse;
 
@@ -327,6 +431,13 @@ Interface PaymentSourceActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateBankAccountPaymentSourceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createBankAccount(array $params, array $headers = []): CreateBankAccountPaymentSourceResponse;
 
@@ -342,6 +453,13 @@ Interface PaymentSourceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateBankAccountPaymentSourceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function updateBankAccount(string $id, array $params = [], array $headers = []): UpdateBankAccountPaymentSourceResponse;
 

--- a/src/Actions/Contracts/PaymentSourceActionsInterface.php
+++ b/src/Actions/Contracts/PaymentSourceActionsInterface.php
@@ -18,7 +18,6 @@ use Chargebee\Responses\PaymentSourceResponse\CreateUsingPaymentIntentPaymentSou
 use Chargebee\Responses\PaymentSourceResponse\VerifyBankAccountPaymentSourceResponse;
 use Chargebee\Responses\PaymentSourceResponse\CreateVoucherPaymentSourcePaymentSourceResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -68,12 +67,10 @@ Interface PaymentSourceActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateUsingPermanentTokenPaymentSourceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createUsingPermanentToken(array $params, array $headers = []): CreateUsingPermanentTokenPaymentSourceResponse;
 
@@ -84,12 +81,10 @@ Interface PaymentSourceActionsInterface
     *   @param array<string, string> $headers
     *   @return DeletePaymentSourceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeletePaymentSourceResponse;
 
@@ -121,12 +116,10 @@ Interface PaymentSourceActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateCardPaymentSourceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createCard(array $params, array $headers = []): CreateCardPaymentSourceResponse;
 
@@ -140,12 +133,10 @@ Interface PaymentSourceActionsInterface
     *   @param array<string, string> $headers
     *   @return VerifyBankAccountPaymentSourceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function verifyBankAccount(string $id, array $params, array $headers = []): VerifyBankAccountPaymentSourceResponse;
 
@@ -196,12 +187,10 @@ Interface PaymentSourceActionsInterface
     *   @param array<string, string> $headers
     *   @return ListPaymentSourceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListPaymentSourceResponse;
 
@@ -214,12 +203,10 @@ Interface PaymentSourceActionsInterface
     *   @param array<string, string> $headers
     *   @return ExportPaymentSourcePaymentSourceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function exportPaymentSource(string $id, array $params, array $headers = []): ExportPaymentSourcePaymentSourceResponse;
 
@@ -243,12 +230,10 @@ Interface PaymentSourceActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateUsingPaymentIntentPaymentSourceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createUsingPaymentIntent(array $params, array $headers = []): CreateUsingPaymentIntentPaymentSourceResponse;
 
@@ -259,12 +244,10 @@ Interface PaymentSourceActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrievePaymentSourceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrievePaymentSourceResponse;
 
@@ -283,12 +266,10 @@ Interface PaymentSourceActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateVoucherPaymentSourcePaymentSourceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createVoucherPaymentSource(array $params, array $headers = []): CreateVoucherPaymentSourcePaymentSourceResponse;
 
@@ -307,12 +288,10 @@ Interface PaymentSourceActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateUsingTempTokenPaymentSourceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createUsingTempToken(array $params, array $headers = []): CreateUsingTempTokenPaymentSourceResponse;
 
@@ -340,12 +319,10 @@ Interface PaymentSourceActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateCardPaymentSourceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function updateCard(string $id, array $params = [], array $headers = []): UpdateCardPaymentSourceResponse;
 
@@ -358,12 +335,10 @@ Interface PaymentSourceActionsInterface
     *   @param array<string, string> $headers
     *   @return SwitchGatewayAccountPaymentSourceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function switchGatewayAccount(string $id, array $params, array $headers = []): SwitchGatewayAccountPaymentSourceResponse;
 
@@ -378,12 +353,10 @@ Interface PaymentSourceActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateUsingTokenPaymentSourceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createUsingToken(array $params, array $headers = []): CreateUsingTokenPaymentSourceResponse;
 
@@ -394,12 +367,10 @@ Interface PaymentSourceActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteLocalPaymentSourceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function deleteLocal(string $id, array $headers = []): DeleteLocalPaymentSourceResponse;
 
@@ -432,12 +403,10 @@ Interface PaymentSourceActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateBankAccountPaymentSourceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createBankAccount(array $params, array $headers = []): CreateBankAccountPaymentSourceResponse;
 
@@ -454,12 +423,10 @@ Interface PaymentSourceActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateBankAccountPaymentSourceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function updateBankAccount(string $id, array $params = [], array $headers = []): UpdateBankAccountPaymentSourceResponse;
 

--- a/src/Actions/Contracts/PaymentVoucherActionsInterface.php
+++ b/src/Actions/Contracts/PaymentVoucherActionsInterface.php
@@ -6,7 +6,6 @@ use Chargebee\Responses\PaymentVoucherResponse\RetrievePaymentVoucherResponse;
 use Chargebee\Responses\PaymentVoucherResponse\PaymentVouchersForInvoicePaymentVoucherResponse;
 use Chargebee\Responses\PaymentVoucherResponse\CreatePaymentVoucherResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -35,12 +34,10 @@ Interface PaymentVoucherActionsInterface
     *   @param array<string, string> $headers
     *   @return PaymentVouchersForCustomerPaymentVoucherResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function paymentVouchersForCustomer(string $id, array $params = [], array $headers = []): PaymentVouchersForCustomerPaymentVoucherResponse;
 
@@ -64,12 +61,10 @@ Interface PaymentVoucherActionsInterface
     *   @param array<string, string> $headers
     *   @return PaymentVouchersForInvoicePaymentVoucherResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function paymentVouchersForInvoice(string $id, array $params = [], array $headers = []): PaymentVouchersForInvoicePaymentVoucherResponse;
 
@@ -80,12 +75,10 @@ Interface PaymentVoucherActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrievePaymentVoucherResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrievePaymentVoucherResponse;
 
@@ -105,12 +98,10 @@ Interface PaymentVoucherActionsInterface
     *   @param array<string, string> $headers
     *   @return CreatePaymentVoucherResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreatePaymentVoucherResponse;
 

--- a/src/Actions/Contracts/PaymentVoucherActionsInterface.php
+++ b/src/Actions/Contracts/PaymentVoucherActionsInterface.php
@@ -5,6 +5,12 @@ use Chargebee\Responses\PaymentVoucherResponse\PaymentVouchersForCustomerPayment
 use Chargebee\Responses\PaymentVoucherResponse\RetrievePaymentVoucherResponse;
 use Chargebee\Responses\PaymentVoucherResponse\PaymentVouchersForInvoicePaymentVoucherResponse;
 use Chargebee\Responses\PaymentVoucherResponse\CreatePaymentVoucherResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface PaymentVoucherActionsInterface
 {
@@ -28,6 +34,13 @@ Interface PaymentVoucherActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return PaymentVouchersForCustomerPaymentVoucherResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function paymentVouchersForCustomer(string $id, array $params = [], array $headers = []): PaymentVouchersForCustomerPaymentVoucherResponse;
 
@@ -50,6 +63,13 @@ Interface PaymentVoucherActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return PaymentVouchersForInvoicePaymentVoucherResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function paymentVouchersForInvoice(string $id, array $params = [], array $headers = []): PaymentVouchersForInvoicePaymentVoucherResponse;
 
@@ -59,6 +79,13 @@ Interface PaymentVoucherActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrievePaymentVoucherResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrievePaymentVoucherResponse;
 
@@ -77,6 +104,13 @@ Interface PaymentVoucherActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreatePaymentVoucherResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreatePaymentVoucherResponse;
 

--- a/src/Actions/Contracts/PlanActionsInterface.php
+++ b/src/Actions/Contracts/PlanActionsInterface.php
@@ -8,6 +8,12 @@ use Chargebee\Responses\PlanResponse\DeletePlanResponse;
 use Chargebee\Responses\PlanResponse\RetrievePlanResponse;
 use Chargebee\Responses\PlanResponse\CopyPlanResponse;
 use Chargebee\Responses\PlanResponse\ListPlanResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface PlanActionsInterface
 {
@@ -18,6 +24,13 @@ Interface PlanActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UnarchivePlanResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function unarchive(string $id, array $headers = []): UnarchivePlanResponse;
 
@@ -27,6 +40,13 @@ Interface PlanActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeletePlanResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeletePlanResponse;
 
@@ -41,6 +61,13 @@ Interface PlanActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CopyPlanResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function copy(array $params, array $headers = []): CopyPlanResponse;
 
@@ -154,6 +181,13 @@ Interface PlanActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListPlanResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListPlanResponse;
 
@@ -241,6 +275,13 @@ Interface PlanActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreatePlanResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreatePlanResponse;
 
@@ -250,6 +291,13 @@ Interface PlanActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrievePlanResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrievePlanResponse;
 
@@ -333,6 +381,13 @@ Interface PlanActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdatePlanResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params, array $headers = []): UpdatePlanResponse;
 

--- a/src/Actions/Contracts/PlanActionsInterface.php
+++ b/src/Actions/Contracts/PlanActionsInterface.php
@@ -9,7 +9,6 @@ use Chargebee\Responses\PlanResponse\RetrievePlanResponse;
 use Chargebee\Responses\PlanResponse\CopyPlanResponse;
 use Chargebee\Responses\PlanResponse\ListPlanResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -25,12 +24,10 @@ Interface PlanActionsInterface
     *   @param array<string, string> $headers
     *   @return UnarchivePlanResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function unarchive(string $id, array $headers = []): UnarchivePlanResponse;
 
@@ -41,12 +38,10 @@ Interface PlanActionsInterface
     *   @param array<string, string> $headers
     *   @return DeletePlanResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeletePlanResponse;
 
@@ -62,12 +57,10 @@ Interface PlanActionsInterface
     *   @param array<string, string> $headers
     *   @return CopyPlanResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function copy(array $params, array $headers = []): CopyPlanResponse;
 
@@ -182,12 +175,10 @@ Interface PlanActionsInterface
     *   @param array<string, string> $headers
     *   @return ListPlanResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListPlanResponse;
 
@@ -276,12 +267,10 @@ Interface PlanActionsInterface
     *   @param array<string, string> $headers
     *   @return CreatePlanResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreatePlanResponse;
 
@@ -292,12 +281,10 @@ Interface PlanActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrievePlanResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrievePlanResponse;
 
@@ -382,12 +369,10 @@ Interface PlanActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdatePlanResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params, array $headers = []): UpdatePlanResponse;
 

--- a/src/Actions/Contracts/PortalSessionActionsInterface.php
+++ b/src/Actions/Contracts/PortalSessionActionsInterface.php
@@ -6,7 +6,6 @@ use Chargebee\Responses\PortalSessionResponse\RetrievePortalSessionResponse;
 use Chargebee\Responses\PortalSessionResponse\ActivatePortalSessionResponse;
 use Chargebee\Responses\PortalSessionResponse\LogoutPortalSessionResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -28,12 +27,10 @@ Interface PortalSessionActionsInterface
     *   @param array<string, string> $headers
     *   @return CreatePortalSessionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreatePortalSessionResponse;
 
@@ -46,12 +43,10 @@ Interface PortalSessionActionsInterface
     *   @param array<string, string> $headers
     *   @return ActivatePortalSessionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function activate(string $id, array $params, array $headers = []): ActivatePortalSessionResponse;
 
@@ -62,12 +57,10 @@ Interface PortalSessionActionsInterface
     *   @param array<string, string> $headers
     *   @return LogoutPortalSessionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function logout(string $id, array $headers = []): LogoutPortalSessionResponse;
 
@@ -78,12 +71,10 @@ Interface PortalSessionActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrievePortalSessionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrievePortalSessionResponse;
 

--- a/src/Actions/Contracts/PortalSessionActionsInterface.php
+++ b/src/Actions/Contracts/PortalSessionActionsInterface.php
@@ -5,6 +5,12 @@ use Chargebee\Responses\PortalSessionResponse\CreatePortalSessionResponse;
 use Chargebee\Responses\PortalSessionResponse\RetrievePortalSessionResponse;
 use Chargebee\Responses\PortalSessionResponse\ActivatePortalSessionResponse;
 use Chargebee\Responses\PortalSessionResponse\LogoutPortalSessionResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface PortalSessionActionsInterface
 {
@@ -21,6 +27,13 @@ Interface PortalSessionActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreatePortalSessionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreatePortalSessionResponse;
 
@@ -32,6 +45,13 @@ Interface PortalSessionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ActivatePortalSessionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function activate(string $id, array $params, array $headers = []): ActivatePortalSessionResponse;
 
@@ -41,6 +61,13 @@ Interface PortalSessionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return LogoutPortalSessionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function logout(string $id, array $headers = []): LogoutPortalSessionResponse;
 
@@ -50,6 +77,13 @@ Interface PortalSessionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrievePortalSessionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrievePortalSessionResponse;
 

--- a/src/Actions/Contracts/PriceVariantActionsInterface.php
+++ b/src/Actions/Contracts/PriceVariantActionsInterface.php
@@ -7,7 +7,6 @@ use Chargebee\Responses\PriceVariantResponse\UpdatePriceVariantResponse;
 use Chargebee\Responses\PriceVariantResponse\DeletePriceVariantResponse;
 use Chargebee\Responses\PriceVariantResponse\RetrievePriceVariantResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -23,12 +22,10 @@ Interface PriceVariantActionsInterface
     *   @param array<string, string> $headers
     *   @return DeletePriceVariantResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeletePriceVariantResponse;
 
@@ -85,12 +82,10 @@ Interface PriceVariantActionsInterface
     *   @param array<string, string> $headers
     *   @return ListPriceVariantResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListPriceVariantResponse;
 
@@ -112,12 +107,10 @@ Interface PriceVariantActionsInterface
     *   @param array<string, string> $headers
     *   @return CreatePriceVariantResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreatePriceVariantResponse;
 
@@ -128,12 +121,10 @@ Interface PriceVariantActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrievePriceVariantResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrievePriceVariantResponse;
 
@@ -154,12 +145,10 @@ Interface PriceVariantActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdatePriceVariantResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params, array $headers = []): UpdatePriceVariantResponse;
 

--- a/src/Actions/Contracts/PriceVariantActionsInterface.php
+++ b/src/Actions/Contracts/PriceVariantActionsInterface.php
@@ -6,6 +6,12 @@ use Chargebee\Responses\PriceVariantResponse\CreatePriceVariantResponse;
 use Chargebee\Responses\PriceVariantResponse\UpdatePriceVariantResponse;
 use Chargebee\Responses\PriceVariantResponse\DeletePriceVariantResponse;
 use Chargebee\Responses\PriceVariantResponse\RetrievePriceVariantResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface PriceVariantActionsInterface
 {
@@ -16,6 +22,13 @@ Interface PriceVariantActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeletePriceVariantResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeletePriceVariantResponse;
 
@@ -71,6 +84,13 @@ Interface PriceVariantActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListPriceVariantResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListPriceVariantResponse;
 
@@ -91,6 +111,13 @@ Interface PriceVariantActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreatePriceVariantResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreatePriceVariantResponse;
 
@@ -100,6 +127,13 @@ Interface PriceVariantActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrievePriceVariantResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrievePriceVariantResponse;
 
@@ -119,6 +153,13 @@ Interface PriceVariantActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdatePriceVariantResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params, array $headers = []): UpdatePriceVariantResponse;
 

--- a/src/Actions/Contracts/PricingPageSessionActionsInterface.php
+++ b/src/Actions/Contracts/PricingPageSessionActionsInterface.php
@@ -3,6 +3,12 @@ namespace Chargebee\Actions\Contracts;
     
 use Chargebee\Responses\PricingPageSessionResponse\CreateForNewSubscriptionPricingPageSessionResponse;
 use Chargebee\Responses\PricingPageSessionResponse\CreateForExistingSubscriptionPricingPageSessionResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface PricingPageSessionActionsInterface
 {
@@ -33,6 +39,13 @@ Interface PricingPageSessionActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateForExistingSubscriptionPricingPageSessionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createForExistingSubscription(array $params, array $headers = []): CreateForExistingSubscriptionPricingPageSessionResponse;
 
@@ -104,6 +117,13 @@ Interface PricingPageSessionActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateForNewSubscriptionPricingPageSessionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createForNewSubscription(array $params, array $headers = []): CreateForNewSubscriptionPricingPageSessionResponse;
 

--- a/src/Actions/Contracts/PricingPageSessionActionsInterface.php
+++ b/src/Actions/Contracts/PricingPageSessionActionsInterface.php
@@ -4,7 +4,6 @@ namespace Chargebee\Actions\Contracts;
 use Chargebee\Responses\PricingPageSessionResponse\CreateForNewSubscriptionPricingPageSessionResponse;
 use Chargebee\Responses\PricingPageSessionResponse\CreateForExistingSubscriptionPricingPageSessionResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -40,12 +39,10 @@ Interface PricingPageSessionActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateForExistingSubscriptionPricingPageSessionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createForExistingSubscription(array $params, array $headers = []): CreateForExistingSubscriptionPricingPageSessionResponse;
 
@@ -118,12 +115,10 @@ Interface PricingPageSessionActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateForNewSubscriptionPricingPageSessionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createForNewSubscription(array $params, array $headers = []): CreateForNewSubscriptionPricingPageSessionResponse;
 

--- a/src/Actions/Contracts/PromotionalCreditActionsInterface.php
+++ b/src/Actions/Contracts/PromotionalCreditActionsInterface.php
@@ -6,6 +6,12 @@ use Chargebee\Responses\PromotionalCreditResponse\AddPromotionalCreditResponse;
 use Chargebee\Responses\PromotionalCreditResponse\ListPromotionalCreditResponse;
 use Chargebee\Responses\PromotionalCreditResponse\DeductPromotionalCreditResponse;
 use Chargebee\Responses\PromotionalCreditResponse\SetPromotionalCreditResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface PromotionalCreditActionsInterface
 {
@@ -16,6 +22,13 @@ Interface PromotionalCreditActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrievePromotionalCreditResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrievePromotionalCreditResponse;
 
@@ -50,6 +63,13 @@ Interface PromotionalCreditActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListPromotionalCreditResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListPromotionalCreditResponse;
 
@@ -67,6 +87,13 @@ Interface PromotionalCreditActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return DeductPromotionalCreditResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function deduct(array $params, array $headers = []): DeductPromotionalCreditResponse;
 
@@ -84,6 +111,13 @@ Interface PromotionalCreditActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return SetPromotionalCreditResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function set(array $params, array $headers = []): SetPromotionalCreditResponse;
 
@@ -101,6 +135,13 @@ Interface PromotionalCreditActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return AddPromotionalCreditResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function add(array $params, array $headers = []): AddPromotionalCreditResponse;
 

--- a/src/Actions/Contracts/PromotionalCreditActionsInterface.php
+++ b/src/Actions/Contracts/PromotionalCreditActionsInterface.php
@@ -7,7 +7,6 @@ use Chargebee\Responses\PromotionalCreditResponse\ListPromotionalCreditResponse;
 use Chargebee\Responses\PromotionalCreditResponse\DeductPromotionalCreditResponse;
 use Chargebee\Responses\PromotionalCreditResponse\SetPromotionalCreditResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -23,12 +22,10 @@ Interface PromotionalCreditActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrievePromotionalCreditResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrievePromotionalCreditResponse;
 
@@ -64,12 +61,10 @@ Interface PromotionalCreditActionsInterface
     *   @param array<string, string> $headers
     *   @return ListPromotionalCreditResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListPromotionalCreditResponse;
 
@@ -88,12 +83,10 @@ Interface PromotionalCreditActionsInterface
     *   @param array<string, string> $headers
     *   @return DeductPromotionalCreditResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function deduct(array $params, array $headers = []): DeductPromotionalCreditResponse;
 
@@ -112,12 +105,10 @@ Interface PromotionalCreditActionsInterface
     *   @param array<string, string> $headers
     *   @return SetPromotionalCreditResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function set(array $params, array $headers = []): SetPromotionalCreditResponse;
 
@@ -136,12 +127,10 @@ Interface PromotionalCreditActionsInterface
     *   @param array<string, string> $headers
     *   @return AddPromotionalCreditResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function add(array $params, array $headers = []): AddPromotionalCreditResponse;
 

--- a/src/Actions/Contracts/PurchaseActionsInterface.php
+++ b/src/Actions/Contracts/PurchaseActionsInterface.php
@@ -3,6 +3,12 @@ namespace Chargebee\Actions\Contracts;
     
 use Chargebee\Responses\PurchaseResponse\CreatePurchaseResponse;
 use Chargebee\Responses\PurchaseResponse\EstimatePurchaseResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface PurchaseActionsInterface
 {
@@ -91,6 +97,13 @@ Interface PurchaseActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreatePurchaseResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreatePurchaseResponse;
 
@@ -176,6 +189,13 @@ Interface PurchaseActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return EstimatePurchaseResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function estimate(array $params, array $headers = []): EstimatePurchaseResponse;
 

--- a/src/Actions/Contracts/PurchaseActionsInterface.php
+++ b/src/Actions/Contracts/PurchaseActionsInterface.php
@@ -4,7 +4,6 @@ namespace Chargebee\Actions\Contracts;
 use Chargebee\Responses\PurchaseResponse\CreatePurchaseResponse;
 use Chargebee\Responses\PurchaseResponse\EstimatePurchaseResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -98,12 +97,10 @@ Interface PurchaseActionsInterface
     *   @param array<string, string> $headers
     *   @return CreatePurchaseResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreatePurchaseResponse;
 
@@ -190,12 +187,10 @@ Interface PurchaseActionsInterface
     *   @param array<string, string> $headers
     *   @return EstimatePurchaseResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function estimate(array $params, array $headers = []): EstimatePurchaseResponse;
 

--- a/src/Actions/Contracts/QuoteActionsInterface.php
+++ b/src/Actions/Contracts/QuoteActionsInterface.php
@@ -21,6 +21,12 @@ use Chargebee\Responses\QuoteResponse\UpdateSubscriptionQuoteForItemsQuoteRespon
 use Chargebee\Responses\QuoteResponse\QuoteLineGroupsForQuoteQuoteResponse;
 use Chargebee\Responses\QuoteResponse\EditUpdateSubscriptionQuoteQuoteResponse;
 use Chargebee\Responses\QuoteResponse\ExtendExpiryDateQuoteResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface QuoteActionsInterface
 {
@@ -133,6 +139,13 @@ Interface QuoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CreateSubItemsForCustomerQuoteQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createSubItemsForCustomerQuote(string $id, array $params, array $headers = []): CreateSubItemsForCustomerQuoteQuoteResponse;
 
@@ -142,6 +155,13 @@ Interface QuoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveQuoteResponse;
 
@@ -252,6 +272,13 @@ Interface QuoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return EditCreateSubCustomerQuoteForItemsQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function editCreateSubCustomerQuoteForItems(string $id, array $params, array $headers = []): EditCreateSubCustomerQuoteForItemsQuoteResponse;
 
@@ -264,6 +291,13 @@ Interface QuoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateStatusQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function updateStatus(string $id, array $params, array $headers = []): UpdateStatusQuoteResponse;
 
@@ -390,6 +424,13 @@ Interface QuoteActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return UpdateSubscriptionQuoteForItemsQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function updateSubscriptionQuoteForItems(array $params, array $headers = []): UpdateSubscriptionQuoteForItemsQuoteResponse;
 
@@ -402,6 +443,13 @@ Interface QuoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return QuoteLineGroupsForQuoteQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function quoteLineGroupsForQuote(string $id, array $params = [], array $headers = []): QuoteLineGroupsForQuoteQuoteResponse;
 
@@ -413,6 +461,13 @@ Interface QuoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ExtendExpiryDateQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function extendExpiryDate(string $id, array $params, array $headers = []): ExtendExpiryDateQuoteResponse;
 
@@ -501,6 +556,13 @@ Interface QuoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return EditForChargeItemsAndChargesQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function editForChargeItemsAndCharges(string $id, array $params, array $headers = []): EditForChargeItemsAndChargesQuoteResponse;
 
@@ -625,6 +687,13 @@ Interface QuoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return EditUpdateSubscriptionQuoteForItemsQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function editUpdateSubscriptionQuoteForItems(string $id, array $params, array $headers = []): EditUpdateSubscriptionQuoteForItemsQuoteResponse;
 
@@ -682,6 +751,13 @@ Interface QuoteActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListQuoteResponse;
 
@@ -694,6 +770,13 @@ Interface QuoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return PdfQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function pdf(string $id, array $params = [], array $headers = []): PdfQuoteResponse;
 
@@ -714,6 +797,13 @@ Interface QuoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ConvertQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function convert(string $id, array $params = [], array $headers = []): ConvertQuoteResponse;
 
@@ -804,6 +894,13 @@ Interface QuoteActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateForChargeItemsAndChargesQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createForChargeItemsAndCharges(array $params, array $headers = []): CreateForChargeItemsAndChargesQuoteResponse;
 
@@ -815,6 +912,13 @@ Interface QuoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $params = [], array $headers = []): DeleteQuoteResponse;
 
@@ -869,6 +973,13 @@ Interface QuoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return EditOneTimeQuoteQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function editOneTimeQuote(string $id, array $params = [], array $headers = []): EditOneTimeQuoteQuoteResponse;
 
@@ -970,6 +1081,13 @@ Interface QuoteActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return UpdateSubscriptionQuoteQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function updateSubscriptionQuote(array $params, array $headers = []): UpdateSubscriptionQuoteQuoteResponse;
 
@@ -1026,6 +1144,13 @@ Interface QuoteActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateForOnetimeChargesQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createForOnetimeCharges(array $params, array $headers = []): CreateForOnetimeChargesQuoteResponse;
 
@@ -1098,6 +1223,13 @@ Interface QuoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CreateSubForCustomerQuoteQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createSubForCustomerQuote(string $id, array $params, array $headers = []): CreateSubForCustomerQuoteQuoteResponse;
 
@@ -1197,6 +1329,13 @@ Interface QuoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return EditUpdateSubscriptionQuoteQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function editUpdateSubscriptionQuote(string $id, array $params = [], array $headers = []): EditUpdateSubscriptionQuoteQuoteResponse;
 
@@ -1268,6 +1407,13 @@ Interface QuoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return EditCreateSubForCustomerQuoteQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function editCreateSubForCustomerQuote(string $id, array $params, array $headers = []): EditCreateSubForCustomerQuoteQuoteResponse;
 

--- a/src/Actions/Contracts/QuoteActionsInterface.php
+++ b/src/Actions/Contracts/QuoteActionsInterface.php
@@ -22,7 +22,6 @@ use Chargebee\Responses\QuoteResponse\QuoteLineGroupsForQuoteQuoteResponse;
 use Chargebee\Responses\QuoteResponse\EditUpdateSubscriptionQuoteQuoteResponse;
 use Chargebee\Responses\QuoteResponse\ExtendExpiryDateQuoteResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -140,12 +139,10 @@ Interface QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateSubItemsForCustomerQuoteQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createSubItemsForCustomerQuote(string $id, array $params, array $headers = []): CreateSubItemsForCustomerQuoteQuoteResponse;
 
@@ -156,12 +153,10 @@ Interface QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveQuoteResponse;
 
@@ -273,12 +268,10 @@ Interface QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return EditCreateSubCustomerQuoteForItemsQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function editCreateSubCustomerQuoteForItems(string $id, array $params, array $headers = []): EditCreateSubCustomerQuoteForItemsQuoteResponse;
 
@@ -292,12 +285,10 @@ Interface QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateStatusQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function updateStatus(string $id, array $params, array $headers = []): UpdateStatusQuoteResponse;
 
@@ -425,12 +416,10 @@ Interface QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateSubscriptionQuoteForItemsQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function updateSubscriptionQuoteForItems(array $params, array $headers = []): UpdateSubscriptionQuoteForItemsQuoteResponse;
 
@@ -444,12 +433,10 @@ Interface QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return QuoteLineGroupsForQuoteQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function quoteLineGroupsForQuote(string $id, array $params = [], array $headers = []): QuoteLineGroupsForQuoteQuoteResponse;
 
@@ -462,12 +449,10 @@ Interface QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return ExtendExpiryDateQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function extendExpiryDate(string $id, array $params, array $headers = []): ExtendExpiryDateQuoteResponse;
 
@@ -557,12 +542,10 @@ Interface QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return EditForChargeItemsAndChargesQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function editForChargeItemsAndCharges(string $id, array $params, array $headers = []): EditForChargeItemsAndChargesQuoteResponse;
 
@@ -688,12 +671,10 @@ Interface QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return EditUpdateSubscriptionQuoteForItemsQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function editUpdateSubscriptionQuoteForItems(string $id, array $params, array $headers = []): EditUpdateSubscriptionQuoteForItemsQuoteResponse;
 
@@ -752,12 +733,10 @@ Interface QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return ListQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListQuoteResponse;
 
@@ -771,12 +750,10 @@ Interface QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return PdfQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function pdf(string $id, array $params = [], array $headers = []): PdfQuoteResponse;
 
@@ -798,12 +775,10 @@ Interface QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return ConvertQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function convert(string $id, array $params = [], array $headers = []): ConvertQuoteResponse;
 
@@ -895,12 +870,10 @@ Interface QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateForChargeItemsAndChargesQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createForChargeItemsAndCharges(array $params, array $headers = []): CreateForChargeItemsAndChargesQuoteResponse;
 
@@ -913,12 +886,10 @@ Interface QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $params = [], array $headers = []): DeleteQuoteResponse;
 
@@ -974,12 +945,10 @@ Interface QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return EditOneTimeQuoteQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function editOneTimeQuote(string $id, array $params = [], array $headers = []): EditOneTimeQuoteQuoteResponse;
 
@@ -1082,12 +1051,10 @@ Interface QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateSubscriptionQuoteQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function updateSubscriptionQuote(array $params, array $headers = []): UpdateSubscriptionQuoteQuoteResponse;
 
@@ -1145,12 +1112,10 @@ Interface QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateForOnetimeChargesQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createForOnetimeCharges(array $params, array $headers = []): CreateForOnetimeChargesQuoteResponse;
 
@@ -1224,12 +1189,10 @@ Interface QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateSubForCustomerQuoteQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createSubForCustomerQuote(string $id, array $params, array $headers = []): CreateSubForCustomerQuoteQuoteResponse;
 
@@ -1330,12 +1293,10 @@ Interface QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return EditUpdateSubscriptionQuoteQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function editUpdateSubscriptionQuote(string $id, array $params = [], array $headers = []): EditUpdateSubscriptionQuoteQuoteResponse;
 
@@ -1408,12 +1369,10 @@ Interface QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return EditCreateSubForCustomerQuoteQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function editCreateSubForCustomerQuote(string $id, array $params, array $headers = []): EditCreateSubForCustomerQuoteQuoteResponse;
 

--- a/src/Actions/Contracts/RampActionsInterface.php
+++ b/src/Actions/Contracts/RampActionsInterface.php
@@ -6,6 +6,12 @@ use Chargebee\Responses\RampResponse\RetrieveRampResponse;
 use Chargebee\Responses\RampResponse\UpdateRampResponse;
 use Chargebee\Responses\RampResponse\ListRampResponse;
 use Chargebee\Responses\RampResponse\CreateForSubscriptionRampResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface RampActionsInterface
 {
@@ -16,6 +22,13 @@ Interface RampActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveRampResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveRampResponse;
 
@@ -74,6 +87,13 @@ Interface RampActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CreateForSubscriptionRampResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createForSubscription(string $id, array $params, array $headers = []): CreateForSubscriptionRampResponse;
 
@@ -84,12 +104,12 @@ Interface RampActionsInterface
     *     offset?: string,
     *     include_deleted?: bool,
     *     status?: array{
-    *     is?: mixed,
     *     in?: mixed,
+    *     is?: mixed,
     *     },
     * subscription_id?: array{
-    *     is?: mixed,
     *     in?: mixed,
+    *     is?: mixed,
     *     },
     * effective_from?: array{
     *     after?: mixed,
@@ -111,6 +131,13 @@ Interface RampActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListRampResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params, array $headers = []): ListRampResponse;
 
@@ -169,6 +196,13 @@ Interface RampActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateRampResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params, array $headers = []): UpdateRampResponse;
 
@@ -178,6 +212,13 @@ Interface RampActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteRampResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteRampResponse;
 

--- a/src/Actions/Contracts/RampActionsInterface.php
+++ b/src/Actions/Contracts/RampActionsInterface.php
@@ -7,7 +7,6 @@ use Chargebee\Responses\RampResponse\UpdateRampResponse;
 use Chargebee\Responses\RampResponse\ListRampResponse;
 use Chargebee\Responses\RampResponse\CreateForSubscriptionRampResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -23,12 +22,10 @@ Interface RampActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveRampResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveRampResponse;
 
@@ -88,12 +85,10 @@ Interface RampActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateForSubscriptionRampResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createForSubscription(string $id, array $params, array $headers = []): CreateForSubscriptionRampResponse;
 
@@ -132,12 +127,10 @@ Interface RampActionsInterface
     *   @param array<string, string> $headers
     *   @return ListRampResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params, array $headers = []): ListRampResponse;
 
@@ -197,12 +190,10 @@ Interface RampActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateRampResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params, array $headers = []): UpdateRampResponse;
 
@@ -213,12 +204,10 @@ Interface RampActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteRampResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteRampResponse;
 

--- a/src/Actions/Contracts/RecordedPurchaseActionsInterface.php
+++ b/src/Actions/Contracts/RecordedPurchaseActionsInterface.php
@@ -4,7 +4,6 @@ namespace Chargebee\Actions\Contracts;
 use Chargebee\Responses\RecordedPurchaseResponse\RetrieveRecordedPurchaseResponse;
 use Chargebee\Responses\RecordedPurchaseResponse\CreateRecordedPurchaseResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -20,12 +19,10 @@ Interface RecordedPurchaseActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveRecordedPurchaseResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveRecordedPurchaseResponse;
 
@@ -54,12 +51,10 @@ Interface RecordedPurchaseActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateRecordedPurchaseResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateRecordedPurchaseResponse;
 

--- a/src/Actions/Contracts/RecordedPurchaseActionsInterface.php
+++ b/src/Actions/Contracts/RecordedPurchaseActionsInterface.php
@@ -3,6 +3,12 @@ namespace Chargebee\Actions\Contracts;
     
 use Chargebee\Responses\RecordedPurchaseResponse\RetrieveRecordedPurchaseResponse;
 use Chargebee\Responses\RecordedPurchaseResponse\CreateRecordedPurchaseResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface RecordedPurchaseActionsInterface
 {
@@ -13,6 +19,13 @@ Interface RecordedPurchaseActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveRecordedPurchaseResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveRecordedPurchaseResponse;
 
@@ -40,6 +53,13 @@ Interface RecordedPurchaseActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateRecordedPurchaseResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateRecordedPurchaseResponse;
 

--- a/src/Actions/Contracts/ResourceMigrationActionsInterface.php
+++ b/src/Actions/Contracts/ResourceMigrationActionsInterface.php
@@ -2,6 +2,12 @@
 namespace Chargebee\Actions\Contracts;
     
 use Chargebee\Responses\ResourceMigrationResponse\RetrieveLatestResourceMigrationResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface ResourceMigrationActionsInterface
 {
@@ -16,6 +22,13 @@ Interface ResourceMigrationActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return RetrieveLatestResourceMigrationResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieveLatest(array $params, array $headers = []): RetrieveLatestResourceMigrationResponse;
 

--- a/src/Actions/Contracts/ResourceMigrationActionsInterface.php
+++ b/src/Actions/Contracts/ResourceMigrationActionsInterface.php
@@ -3,7 +3,6 @@ namespace Chargebee\Actions\Contracts;
     
 use Chargebee\Responses\ResourceMigrationResponse\RetrieveLatestResourceMigrationResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -23,12 +22,10 @@ Interface ResourceMigrationActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveLatestResourceMigrationResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieveLatest(array $params, array $headers = []): RetrieveLatestResourceMigrationResponse;
 

--- a/src/Actions/Contracts/RuleActionsInterface.php
+++ b/src/Actions/Contracts/RuleActionsInterface.php
@@ -2,6 +2,12 @@
 namespace Chargebee\Actions\Contracts;
     
 use Chargebee\Responses\RuleResponse\RetrieveRuleResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface RuleActionsInterface
 {
@@ -12,6 +18,13 @@ Interface RuleActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveRuleResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveRuleResponse;
 

--- a/src/Actions/Contracts/RuleActionsInterface.php
+++ b/src/Actions/Contracts/RuleActionsInterface.php
@@ -3,7 +3,6 @@ namespace Chargebee\Actions\Contracts;
     
 use Chargebee\Responses\RuleResponse\RetrieveRuleResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -19,12 +18,10 @@ Interface RuleActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveRuleResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveRuleResponse;
 

--- a/src/Actions/Contracts/SiteMigrationDetailActionsInterface.php
+++ b/src/Actions/Contracts/SiteMigrationDetailActionsInterface.php
@@ -2,6 +2,12 @@
 namespace Chargebee\Actions\Contracts;
     
 use Chargebee\Responses\SiteMigrationDetailResponse\ListSiteMigrationDetailResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface SiteMigrationDetailActionsInterface
 {
@@ -42,6 +48,13 @@ Interface SiteMigrationDetailActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListSiteMigrationDetailResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListSiteMigrationDetailResponse;
 

--- a/src/Actions/Contracts/SiteMigrationDetailActionsInterface.php
+++ b/src/Actions/Contracts/SiteMigrationDetailActionsInterface.php
@@ -3,7 +3,6 @@ namespace Chargebee\Actions\Contracts;
     
 use Chargebee\Responses\SiteMigrationDetailResponse\ListSiteMigrationDetailResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -49,12 +48,10 @@ Interface SiteMigrationDetailActionsInterface
     *   @param array<string, string> $headers
     *   @return ListSiteMigrationDetailResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListSiteMigrationDetailResponse;
 

--- a/src/Actions/Contracts/SubscriptionActionsInterface.php
+++ b/src/Actions/Contracts/SubscriptionActionsInterface.php
@@ -38,6 +38,12 @@ use Chargebee\Responses\SubscriptionResponse\RemoveAdvanceInvoiceScheduleSubscri
 use Chargebee\Responses\SubscriptionResponse\ImportForItemsSubscriptionResponse;
 use Chargebee\Responses\SubscriptionResponse\EditAdvanceInvoiceScheduleSubscriptionResponse;
 use Chargebee\Responses\SubscriptionResponse\ImportForCustomerSubscriptionResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface SubscriptionActionsInterface
 {
@@ -52,6 +58,13 @@ Interface SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RemoveAdvanceInvoiceScheduleSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function removeAdvanceInvoiceSchedule(string $id, array $params = [], array $headers = []): RemoveAdvanceInvoiceScheduleSubscriptionResponse;
 
@@ -235,6 +248,13 @@ Interface SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateForItemsSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function updateForItems(string $id, array $params, array $headers = []): UpdateForItemsSubscriptionResponse;
 
@@ -246,6 +266,13 @@ Interface SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RemoveCouponsSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function removeCoupons(string $id, array $params = [], array $headers = []): RemoveCouponsSubscriptionResponse;
 
@@ -270,6 +297,13 @@ Interface SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ResumeSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function resume(string $id, array $params = [], array $headers = []): ResumeSubscriptionResponse;
 
@@ -298,6 +332,13 @@ Interface SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CancelForItemsSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function cancelForItems(string $id, array $params = [], array $headers = []): CancelForItemsSubscriptionResponse;
 
@@ -312,6 +353,13 @@ Interface SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RegenerateInvoiceSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function regenerateInvoice(string $id, array $params = [], array $headers = []): RegenerateInvoiceSubscriptionResponse;
 
@@ -449,6 +497,13 @@ Interface SubscriptionActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListSubscriptionResponse;
 
@@ -650,6 +705,13 @@ Interface SubscriptionActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateSubscriptionResponse;
 
@@ -662,6 +724,13 @@ Interface SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return MoveSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function move(string $id, array $params, array $headers = []): MoveSubscriptionResponse;
 
@@ -674,6 +743,13 @@ Interface SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return SubscriptionsForCustomerSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function subscriptionsForCustomer(string $id, array $params = [], array $headers = []): SubscriptionsForCustomerSubscriptionResponse;
 
@@ -770,6 +846,13 @@ Interface SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CreateForCustomerSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createForCustomer(string $id, array $params, array $headers = []): CreateForCustomerSubscriptionResponse;
 
@@ -882,6 +965,13 @@ Interface SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ImportForItemsSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function importForItems(string $id, array $params, array $headers = []): ImportForItemsSubscriptionResponse;
 
@@ -891,6 +981,13 @@ Interface SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveAdvanceInvoiceScheduleSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieveAdvanceInvoiceSchedule(string $id, array $headers = []): RetrieveAdvanceInvoiceScheduleSubscriptionResponse;
 
@@ -907,6 +1004,13 @@ Interface SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RemoveScheduledCancellationSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function removeScheduledCancellation(string $id, array $params = [], array $headers = []): RemoveScheduledCancellationSubscriptionResponse;
 
@@ -916,6 +1020,13 @@ Interface SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveWithScheduledChangesSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieveWithScheduledChanges(string $id, array $headers = []): RetrieveWithScheduledChangesSubscriptionResponse;
 
@@ -952,6 +1063,13 @@ Interface SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ReactivateSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function reactivate(string $id, array $params = [], array $headers = []): ReactivateSubscriptionResponse;
 
@@ -975,6 +1093,13 @@ Interface SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ChargeFutureRenewalsSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function chargeFutureRenewals(string $id, array $params = [], array $headers = []): ChargeFutureRenewalsSubscriptionResponse;
 
@@ -993,6 +1118,13 @@ Interface SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return AddChargeAtTermEndSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function addChargeAtTermEnd(string $id, array $params, array $headers = []): AddChargeAtTermEndSubscriptionResponse;
 
@@ -1002,6 +1134,13 @@ Interface SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RemoveScheduledChangesSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function removeScheduledChanges(string $id, array $headers = []): RemoveScheduledChangesSubscriptionResponse;
 
@@ -1015,6 +1154,13 @@ Interface SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ChangeTermEndSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function changeTermEnd(string $id, array $params, array $headers = []): ChangeTermEndSubscriptionResponse;
 
@@ -1024,6 +1170,13 @@ Interface SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteSubscriptionResponse;
 
@@ -1141,6 +1294,13 @@ Interface SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CreateWithItemsSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createWithItems(string $id, array $params, array $headers = []): CreateWithItemsSubscriptionResponse;
 
@@ -1186,6 +1346,13 @@ Interface SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ImportUnbilledChargesSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function importUnbilledCharges(string $id, array $params, array $headers = []): ImportUnbilledChargesSubscriptionResponse;
 
@@ -1195,6 +1362,13 @@ Interface SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RemoveScheduledResumptionSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function removeScheduledResumption(string $id, array $headers = []): RemoveScheduledResumptionSubscriptionResponse;
 
@@ -1204,6 +1378,13 @@ Interface SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveSubscriptionResponse;
 
@@ -1363,6 +1544,13 @@ Interface SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdateSubscriptionResponse;
 
@@ -1388,6 +1576,13 @@ Interface SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ImportContractTermSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function importContractTerm(string $id, array $params = [], array $headers = []): ImportContractTermSubscriptionResponse;
 
@@ -1400,6 +1595,13 @@ Interface SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return OverrideBillingProfileSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function overrideBillingProfile(string $id, array $params = [], array $headers = []): OverrideBillingProfileSubscriptionResponse;
 
@@ -1409,6 +1611,13 @@ Interface SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RemoveScheduledPauseSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function removeScheduledPause(string $id, array $headers = []): RemoveScheduledPauseSubscriptionResponse;
 
@@ -1432,6 +1641,13 @@ Interface SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return EditAdvanceInvoiceScheduleSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function editAdvanceInvoiceSchedule(string $id, array $params = [], array $headers = []): EditAdvanceInvoiceScheduleSubscriptionResponse;
 
@@ -1444,6 +1660,13 @@ Interface SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ListDiscountsSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function listDiscounts(string $id, array $params = [], array $headers = []): ListDiscountsSubscriptionResponse;
 
@@ -1460,6 +1683,13 @@ Interface SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ContractTermsForSubscriptionSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function contractTermsForSubscription(string $id, array $params = [], array $headers = []): ContractTermsForSubscriptionSubscriptionResponse;
 
@@ -1476,6 +1706,13 @@ Interface SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return PauseSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function pause(string $id, array $params = [], array $headers = []): PauseSubscriptionResponse;
 
@@ -1571,6 +1808,13 @@ Interface SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ImportForCustomerSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function importForCustomer(string $id, array $params, array $headers = []): ImportForCustomerSubscriptionResponse;
 
@@ -1730,6 +1974,13 @@ Interface SubscriptionActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ImportSubscriptionSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function importSubscription(array $params, array $headers = []): ImportSubscriptionSubscriptionResponse;
 
@@ -1756,6 +2007,13 @@ Interface SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CancelSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function cancel(string $id, array $params = [], array $headers = []): CancelSubscriptionResponse;
 
@@ -1773,6 +2031,13 @@ Interface SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ChargeAddonAtTermEndSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function chargeAddonAtTermEnd(string $id, array $params, array $headers = []): ChargeAddonAtTermEndSubscriptionResponse;
 

--- a/src/Actions/Contracts/SubscriptionActionsInterface.php
+++ b/src/Actions/Contracts/SubscriptionActionsInterface.php
@@ -39,7 +39,6 @@ use Chargebee\Responses\SubscriptionResponse\ImportForItemsSubscriptionResponse;
 use Chargebee\Responses\SubscriptionResponse\EditAdvanceInvoiceScheduleSubscriptionResponse;
 use Chargebee\Responses\SubscriptionResponse\ImportForCustomerSubscriptionResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -59,12 +58,10 @@ Interface SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return RemoveAdvanceInvoiceScheduleSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function removeAdvanceInvoiceSchedule(string $id, array $params = [], array $headers = []): RemoveAdvanceInvoiceScheduleSubscriptionResponse;
 
@@ -249,12 +246,10 @@ Interface SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateForItemsSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function updateForItems(string $id, array $params, array $headers = []): UpdateForItemsSubscriptionResponse;
 
@@ -267,12 +262,10 @@ Interface SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return RemoveCouponsSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function removeCoupons(string $id, array $params = [], array $headers = []): RemoveCouponsSubscriptionResponse;
 
@@ -298,12 +291,10 @@ Interface SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return ResumeSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function resume(string $id, array $params = [], array $headers = []): ResumeSubscriptionResponse;
 
@@ -333,12 +324,10 @@ Interface SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return CancelForItemsSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function cancelForItems(string $id, array $params = [], array $headers = []): CancelForItemsSubscriptionResponse;
 
@@ -354,12 +343,10 @@ Interface SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return RegenerateInvoiceSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function regenerateInvoice(string $id, array $params = [], array $headers = []): RegenerateInvoiceSubscriptionResponse;
 
@@ -498,12 +485,10 @@ Interface SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return ListSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListSubscriptionResponse;
 
@@ -706,12 +691,10 @@ Interface SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateSubscriptionResponse;
 
@@ -725,12 +708,10 @@ Interface SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return MoveSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function move(string $id, array $params, array $headers = []): MoveSubscriptionResponse;
 
@@ -744,12 +725,10 @@ Interface SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return SubscriptionsForCustomerSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function subscriptionsForCustomer(string $id, array $params = [], array $headers = []): SubscriptionsForCustomerSubscriptionResponse;
 
@@ -847,12 +826,10 @@ Interface SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateForCustomerSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createForCustomer(string $id, array $params, array $headers = []): CreateForCustomerSubscriptionResponse;
 
@@ -966,12 +943,10 @@ Interface SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return ImportForItemsSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function importForItems(string $id, array $params, array $headers = []): ImportForItemsSubscriptionResponse;
 
@@ -982,12 +957,10 @@ Interface SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveAdvanceInvoiceScheduleSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieveAdvanceInvoiceSchedule(string $id, array $headers = []): RetrieveAdvanceInvoiceScheduleSubscriptionResponse;
 
@@ -1005,12 +978,10 @@ Interface SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return RemoveScheduledCancellationSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function removeScheduledCancellation(string $id, array $params = [], array $headers = []): RemoveScheduledCancellationSubscriptionResponse;
 
@@ -1021,12 +992,10 @@ Interface SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveWithScheduledChangesSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieveWithScheduledChanges(string $id, array $headers = []): RetrieveWithScheduledChangesSubscriptionResponse;
 
@@ -1064,12 +1033,10 @@ Interface SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return ReactivateSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function reactivate(string $id, array $params = [], array $headers = []): ReactivateSubscriptionResponse;
 
@@ -1094,12 +1061,10 @@ Interface SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return ChargeFutureRenewalsSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function chargeFutureRenewals(string $id, array $params = [], array $headers = []): ChargeFutureRenewalsSubscriptionResponse;
 
@@ -1119,12 +1084,10 @@ Interface SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return AddChargeAtTermEndSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function addChargeAtTermEnd(string $id, array $params, array $headers = []): AddChargeAtTermEndSubscriptionResponse;
 
@@ -1135,12 +1098,10 @@ Interface SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return RemoveScheduledChangesSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function removeScheduledChanges(string $id, array $headers = []): RemoveScheduledChangesSubscriptionResponse;
 
@@ -1155,12 +1116,10 @@ Interface SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return ChangeTermEndSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function changeTermEnd(string $id, array $params, array $headers = []): ChangeTermEndSubscriptionResponse;
 
@@ -1171,12 +1130,10 @@ Interface SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteSubscriptionResponse;
 
@@ -1295,12 +1252,10 @@ Interface SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateWithItemsSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createWithItems(string $id, array $params, array $headers = []): CreateWithItemsSubscriptionResponse;
 
@@ -1347,12 +1302,10 @@ Interface SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return ImportUnbilledChargesSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function importUnbilledCharges(string $id, array $params, array $headers = []): ImportUnbilledChargesSubscriptionResponse;
 
@@ -1363,12 +1316,10 @@ Interface SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return RemoveScheduledResumptionSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function removeScheduledResumption(string $id, array $headers = []): RemoveScheduledResumptionSubscriptionResponse;
 
@@ -1379,12 +1330,10 @@ Interface SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveSubscriptionResponse;
 
@@ -1545,12 +1494,10 @@ Interface SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdateSubscriptionResponse;
 
@@ -1577,12 +1524,10 @@ Interface SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return ImportContractTermSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function importContractTerm(string $id, array $params = [], array $headers = []): ImportContractTermSubscriptionResponse;
 
@@ -1596,12 +1541,10 @@ Interface SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return OverrideBillingProfileSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function overrideBillingProfile(string $id, array $params = [], array $headers = []): OverrideBillingProfileSubscriptionResponse;
 
@@ -1612,12 +1555,10 @@ Interface SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return RemoveScheduledPauseSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function removeScheduledPause(string $id, array $headers = []): RemoveScheduledPauseSubscriptionResponse;
 
@@ -1642,12 +1583,10 @@ Interface SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return EditAdvanceInvoiceScheduleSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function editAdvanceInvoiceSchedule(string $id, array $params = [], array $headers = []): EditAdvanceInvoiceScheduleSubscriptionResponse;
 
@@ -1661,12 +1600,10 @@ Interface SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return ListDiscountsSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function listDiscounts(string $id, array $params = [], array $headers = []): ListDiscountsSubscriptionResponse;
 
@@ -1684,12 +1621,10 @@ Interface SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return ContractTermsForSubscriptionSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function contractTermsForSubscription(string $id, array $params = [], array $headers = []): ContractTermsForSubscriptionSubscriptionResponse;
 
@@ -1707,12 +1642,10 @@ Interface SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return PauseSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function pause(string $id, array $params = [], array $headers = []): PauseSubscriptionResponse;
 
@@ -1809,12 +1742,10 @@ Interface SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return ImportForCustomerSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function importForCustomer(string $id, array $params, array $headers = []): ImportForCustomerSubscriptionResponse;
 
@@ -1975,12 +1906,10 @@ Interface SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return ImportSubscriptionSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function importSubscription(array $params, array $headers = []): ImportSubscriptionSubscriptionResponse;
 
@@ -2008,12 +1937,10 @@ Interface SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return CancelSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function cancel(string $id, array $params = [], array $headers = []): CancelSubscriptionResponse;
 
@@ -2032,12 +1959,10 @@ Interface SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return ChargeAddonAtTermEndSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function chargeAddonAtTermEnd(string $id, array $params, array $headers = []): ChargeAddonAtTermEndSubscriptionResponse;
 

--- a/src/Actions/Contracts/SubscriptionEntitlementActionsInterface.php
+++ b/src/Actions/Contracts/SubscriptionEntitlementActionsInterface.php
@@ -4,7 +4,6 @@ namespace Chargebee\Actions\Contracts;
 use Chargebee\Responses\SubscriptionEntitlementResponse\SetSubscriptionEntitlementAvailabilitySubscriptionEntitlementResponse;
 use Chargebee\Responses\SubscriptionEntitlementResponse\SubscriptionEntitlementsForSubscriptionSubscriptionEntitlementResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -25,12 +24,10 @@ Interface SubscriptionEntitlementActionsInterface
     *   @param array<string, string> $headers
     *   @return SetSubscriptionEntitlementAvailabilitySubscriptionEntitlementResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function setSubscriptionEntitlementAvailability(string $id, array $params, array $headers = []): SetSubscriptionEntitlementAvailabilitySubscriptionEntitlementResponse;
 
@@ -47,12 +44,10 @@ Interface SubscriptionEntitlementActionsInterface
     *   @param array<string, string> $headers
     *   @return SubscriptionEntitlementsForSubscriptionSubscriptionEntitlementResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function subscriptionEntitlementsForSubscription(string $id, array $params = [], array $headers = []): SubscriptionEntitlementsForSubscriptionSubscriptionEntitlementResponse;
 

--- a/src/Actions/Contracts/SubscriptionEntitlementActionsInterface.php
+++ b/src/Actions/Contracts/SubscriptionEntitlementActionsInterface.php
@@ -3,6 +3,12 @@ namespace Chargebee\Actions\Contracts;
     
 use Chargebee\Responses\SubscriptionEntitlementResponse\SetSubscriptionEntitlementAvailabilitySubscriptionEntitlementResponse;
 use Chargebee\Responses\SubscriptionEntitlementResponse\SubscriptionEntitlementsForSubscriptionSubscriptionEntitlementResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface SubscriptionEntitlementActionsInterface
 {
@@ -18,6 +24,13 @@ Interface SubscriptionEntitlementActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return SetSubscriptionEntitlementAvailabilitySubscriptionEntitlementResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function setSubscriptionEntitlementAvailability(string $id, array $params, array $headers = []): SetSubscriptionEntitlementAvailabilitySubscriptionEntitlementResponse;
 
@@ -33,6 +46,13 @@ Interface SubscriptionEntitlementActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return SubscriptionEntitlementsForSubscriptionSubscriptionEntitlementResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function subscriptionEntitlementsForSubscription(string $id, array $params = [], array $headers = []): SubscriptionEntitlementsForSubscriptionSubscriptionEntitlementResponse;
 

--- a/src/Actions/Contracts/TimeMachineActionsInterface.php
+++ b/src/Actions/Contracts/TimeMachineActionsInterface.php
@@ -4,6 +4,12 @@ namespace Chargebee\Actions\Contracts;
 use Chargebee\Responses\TimeMachineResponse\TravelForwardTimeMachineResponse;
 use Chargebee\Responses\TimeMachineResponse\RetrieveTimeMachineResponse;
 use Chargebee\Responses\TimeMachineResponse\StartAfreshTimeMachineResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface TimeMachineActionsInterface
 {
@@ -14,6 +20,13 @@ Interface TimeMachineActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveTimeMachineResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveTimeMachineResponse;
 
@@ -25,6 +38,13 @@ Interface TimeMachineActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return TravelForwardTimeMachineResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function travelForward(string $id, array $params = [], array $headers = []): TravelForwardTimeMachineResponse;
 
@@ -36,6 +56,13 @@ Interface TimeMachineActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return StartAfreshTimeMachineResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function startAfresh(string $id, array $params = [], array $headers = []): StartAfreshTimeMachineResponse;
 

--- a/src/Actions/Contracts/TimeMachineActionsInterface.php
+++ b/src/Actions/Contracts/TimeMachineActionsInterface.php
@@ -5,7 +5,6 @@ use Chargebee\Responses\TimeMachineResponse\TravelForwardTimeMachineResponse;
 use Chargebee\Responses\TimeMachineResponse\RetrieveTimeMachineResponse;
 use Chargebee\Responses\TimeMachineResponse\StartAfreshTimeMachineResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -21,12 +20,10 @@ Interface TimeMachineActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveTimeMachineResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveTimeMachineResponse;
 
@@ -39,12 +36,10 @@ Interface TimeMachineActionsInterface
     *   @param array<string, string> $headers
     *   @return TravelForwardTimeMachineResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function travelForward(string $id, array $params = [], array $headers = []): TravelForwardTimeMachineResponse;
 
@@ -57,12 +52,10 @@ Interface TimeMachineActionsInterface
     *   @param array<string, string> $headers
     *   @return StartAfreshTimeMachineResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function startAfresh(string $id, array $params = [], array $headers = []): StartAfreshTimeMachineResponse;
 

--- a/src/Actions/Contracts/TransactionActionsInterface.php
+++ b/src/Actions/Contracts/TransactionActionsInterface.php
@@ -14,7 +14,6 @@ use Chargebee\Responses\TransactionResponse\VoidTransactionTransactionResponse;
 use Chargebee\Responses\TransactionResponse\SyncTransactionTransactionResponse;
 use Chargebee\Responses\TransactionResponse\RetrieveTransactionResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -141,12 +140,10 @@ Interface TransactionActionsInterface
     *   @param array<string, string> $headers
     *   @return ListTransactionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListTransactionResponse;
 
@@ -161,12 +158,10 @@ Interface TransactionActionsInterface
     *   @param array<string, string> $headers
     *   @return ReconcileTransactionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function reconcile(string $id, array $params = [], array $headers = []): ReconcileTransactionResponse;
 
@@ -177,12 +172,10 @@ Interface TransactionActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveTransactionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveTransactionResponse;
 
@@ -196,12 +189,10 @@ Interface TransactionActionsInterface
     *   @param array<string, string> $headers
     *   @return RefundTransactionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function refund(string $id, array $params = [], array $headers = []): RefundTransactionResponse;
 
@@ -215,12 +206,10 @@ Interface TransactionActionsInterface
     *   @param array<string, string> $headers
     *   @return TransactionsForCustomerTransactionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function transactionsForCustomer(string $id, array $params = [], array $headers = []): TransactionsForCustomerTransactionResponse;
 
@@ -238,12 +227,10 @@ Interface TransactionActionsInterface
     *   @param array<string, string> $headers
     *   @return RecordRefundTransactionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function recordRefund(string $id, array $params, array $headers = []): RecordRefundTransactionResponse;
 
@@ -257,12 +244,10 @@ Interface TransactionActionsInterface
     *   @param array<string, string> $headers
     *   @return TransactionsForSubscriptionTransactionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function transactionsForSubscription(string $id, array $params = [], array $headers = []): TransactionsForSubscriptionTransactionResponse;
 
@@ -273,12 +258,10 @@ Interface TransactionActionsInterface
     *   @param array<string, string> $headers
     *   @return VoidTransactionTransactionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function voidTransaction(string $id, array $headers = []): VoidTransactionTransactionResponse;
 
@@ -289,12 +272,10 @@ Interface TransactionActionsInterface
     *   @param array<string, string> $headers
     *   @return SyncTransactionTransactionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function syncTransaction(string $id, array $headers = []): SyncTransactionTransactionResponse;
 
@@ -310,12 +291,10 @@ Interface TransactionActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateAuthorizationTransactionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createAuthorization(array $params, array $headers = []): CreateAuthorizationTransactionResponse;
 
@@ -329,12 +308,10 @@ Interface TransactionActionsInterface
     *   @param array<string, string> $headers
     *   @return PaymentsForInvoiceTransactionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function paymentsForInvoice(string $id, array $params = [], array $headers = []): PaymentsForInvoiceTransactionResponse;
 
@@ -347,12 +324,10 @@ Interface TransactionActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteOfflineTransactionTransactionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function deleteOfflineTransaction(string $id, array $params = [], array $headers = []): DeleteOfflineTransactionTransactionResponse;
 

--- a/src/Actions/Contracts/TransactionActionsInterface.php
+++ b/src/Actions/Contracts/TransactionActionsInterface.php
@@ -13,6 +13,12 @@ use Chargebee\Responses\TransactionResponse\PaymentsForInvoiceTransactionRespons
 use Chargebee\Responses\TransactionResponse\VoidTransactionTransactionResponse;
 use Chargebee\Responses\TransactionResponse\SyncTransactionTransactionResponse;
 use Chargebee\Responses\TransactionResponse\RetrieveTransactionResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface TransactionActionsInterface
 {
@@ -134,6 +140,13 @@ Interface TransactionActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListTransactionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListTransactionResponse;
 
@@ -147,6 +160,13 @@ Interface TransactionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ReconcileTransactionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function reconcile(string $id, array $params = [], array $headers = []): ReconcileTransactionResponse;
 
@@ -156,6 +176,13 @@ Interface TransactionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveTransactionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveTransactionResponse;
 
@@ -168,6 +195,13 @@ Interface TransactionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RefundTransactionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function refund(string $id, array $params = [], array $headers = []): RefundTransactionResponse;
 
@@ -180,6 +214,13 @@ Interface TransactionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return TransactionsForCustomerTransactionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function transactionsForCustomer(string $id, array $params = [], array $headers = []): TransactionsForCustomerTransactionResponse;
 
@@ -196,6 +237,13 @@ Interface TransactionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RecordRefundTransactionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function recordRefund(string $id, array $params, array $headers = []): RecordRefundTransactionResponse;
 
@@ -208,6 +256,13 @@ Interface TransactionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return TransactionsForSubscriptionTransactionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function transactionsForSubscription(string $id, array $params = [], array $headers = []): TransactionsForSubscriptionTransactionResponse;
 
@@ -217,6 +272,13 @@ Interface TransactionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return VoidTransactionTransactionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function voidTransaction(string $id, array $headers = []): VoidTransactionTransactionResponse;
 
@@ -226,6 +288,13 @@ Interface TransactionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return SyncTransactionTransactionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function syncTransaction(string $id, array $headers = []): SyncTransactionTransactionResponse;
 
@@ -240,6 +309,13 @@ Interface TransactionActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateAuthorizationTransactionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createAuthorization(array $params, array $headers = []): CreateAuthorizationTransactionResponse;
 
@@ -252,6 +328,13 @@ Interface TransactionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return PaymentsForInvoiceTransactionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function paymentsForInvoice(string $id, array $params = [], array $headers = []): PaymentsForInvoiceTransactionResponse;
 
@@ -263,6 +346,13 @@ Interface TransactionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteOfflineTransactionTransactionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function deleteOfflineTransaction(string $id, array $params = [], array $headers = []): DeleteOfflineTransactionTransactionResponse;
 

--- a/src/Actions/Contracts/UnbilledChargeActionsInterface.php
+++ b/src/Actions/Contracts/UnbilledChargeActionsInterface.php
@@ -7,6 +7,12 @@ use Chargebee\Responses\UnbilledChargeResponse\ListUnbilledChargeResponse;
 use Chargebee\Responses\UnbilledChargeResponse\InvoiceNowEstimateUnbilledChargeResponse;
 use Chargebee\Responses\UnbilledChargeResponse\InvoiceUnbilledChargesUnbilledChargeResponse;
 use Chargebee\Responses\UnbilledChargeResponse\CreateUnbilledChargeUnbilledChargeResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface UnbilledChargeActionsInterface
 {
@@ -17,6 +23,13 @@ Interface UnbilledChargeActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteUnbilledChargeResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteUnbilledChargeResponse;
 
@@ -29,6 +42,13 @@ Interface UnbilledChargeActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return InvoiceNowEstimateUnbilledChargeResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function invoiceNowEstimate(array $params = [], array $headers = []): InvoiceNowEstimateUnbilledChargeResponse;
 
@@ -41,6 +61,13 @@ Interface UnbilledChargeActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return InvoiceUnbilledChargesUnbilledChargeResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function invoiceUnbilledCharges(array $params = [], array $headers = []): InvoiceUnbilledChargesUnbilledChargeResponse;
 
@@ -71,6 +98,13 @@ Interface UnbilledChargeActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListUnbilledChargeResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListUnbilledChargeResponse;
 
@@ -123,6 +157,13 @@ Interface UnbilledChargeActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateUnbilledChargeResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateUnbilledChargeResponse;
 
@@ -164,6 +205,13 @@ Interface UnbilledChargeActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateUnbilledChargeUnbilledChargeResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createUnbilledCharge(array $params, array $headers = []): CreateUnbilledChargeUnbilledChargeResponse;
 

--- a/src/Actions/Contracts/UnbilledChargeActionsInterface.php
+++ b/src/Actions/Contracts/UnbilledChargeActionsInterface.php
@@ -8,7 +8,6 @@ use Chargebee\Responses\UnbilledChargeResponse\InvoiceNowEstimateUnbilledChargeR
 use Chargebee\Responses\UnbilledChargeResponse\InvoiceUnbilledChargesUnbilledChargeResponse;
 use Chargebee\Responses\UnbilledChargeResponse\CreateUnbilledChargeUnbilledChargeResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -24,12 +23,10 @@ Interface UnbilledChargeActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteUnbilledChargeResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteUnbilledChargeResponse;
 
@@ -43,12 +40,10 @@ Interface UnbilledChargeActionsInterface
     *   @param array<string, string> $headers
     *   @return InvoiceNowEstimateUnbilledChargeResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function invoiceNowEstimate(array $params = [], array $headers = []): InvoiceNowEstimateUnbilledChargeResponse;
 
@@ -62,12 +57,10 @@ Interface UnbilledChargeActionsInterface
     *   @param array<string, string> $headers
     *   @return InvoiceUnbilledChargesUnbilledChargeResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function invoiceUnbilledCharges(array $params = [], array $headers = []): InvoiceUnbilledChargesUnbilledChargeResponse;
 
@@ -99,12 +92,10 @@ Interface UnbilledChargeActionsInterface
     *   @param array<string, string> $headers
     *   @return ListUnbilledChargeResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListUnbilledChargeResponse;
 
@@ -158,12 +149,10 @@ Interface UnbilledChargeActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateUnbilledChargeResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateUnbilledChargeResponse;
 
@@ -206,12 +195,10 @@ Interface UnbilledChargeActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateUnbilledChargeUnbilledChargeResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createUnbilledCharge(array $params, array $headers = []): CreateUnbilledChargeUnbilledChargeResponse;
 

--- a/src/Actions/Contracts/UsageActionsInterface.php
+++ b/src/Actions/Contracts/UsageActionsInterface.php
@@ -7,7 +7,6 @@ use Chargebee\Responses\UsageResponse\ListUsageResponse;
 use Chargebee\Responses\UsageResponse\PdfUsageResponse;
 use Chargebee\Responses\UsageResponse\DeleteUsageResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -28,12 +27,10 @@ Interface UsageActionsInterface
     *   @param array<string, string> $headers
     *   @return PdfUsageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function pdf(array $params, array $headers = []): PdfUsageResponse;
 
@@ -46,12 +43,10 @@ Interface UsageActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveUsageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $params, array $headers = []): RetrieveUsageResponse;
 
@@ -69,12 +64,10 @@ Interface UsageActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateUsageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(string $id, array $params, array $headers = []): CreateUsageResponse;
 
@@ -87,12 +80,10 @@ Interface UsageActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteUsageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $params, array $headers = []): DeleteUsageResponse;
 
@@ -149,12 +140,10 @@ Interface UsageActionsInterface
     *   @param array<string, string> $headers
     *   @return ListUsageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListUsageResponse;
 

--- a/src/Actions/Contracts/UsageActionsInterface.php
+++ b/src/Actions/Contracts/UsageActionsInterface.php
@@ -6,6 +6,12 @@ use Chargebee\Responses\UsageResponse\CreateUsageResponse;
 use Chargebee\Responses\UsageResponse\ListUsageResponse;
 use Chargebee\Responses\UsageResponse\PdfUsageResponse;
 use Chargebee\Responses\UsageResponse\DeleteUsageResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface UsageActionsInterface
 {
@@ -21,6 +27,13 @@ Interface UsageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return PdfUsageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function pdf(array $params, array $headers = []): PdfUsageResponse;
 
@@ -32,6 +45,13 @@ Interface UsageActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveUsageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $params, array $headers = []): RetrieveUsageResponse;
 
@@ -48,6 +68,13 @@ Interface UsageActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CreateUsageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(string $id, array $params, array $headers = []): CreateUsageResponse;
 
@@ -59,6 +86,13 @@ Interface UsageActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteUsageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $params, array $headers = []): DeleteUsageResponse;
 
@@ -114,6 +148,13 @@ Interface UsageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListUsageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListUsageResponse;
 

--- a/src/Actions/Contracts/UsageEventActionsInterface.php
+++ b/src/Actions/Contracts/UsageEventActionsInterface.php
@@ -4,7 +4,6 @@ namespace Chargebee\Actions\Contracts;
 use Chargebee\Responses\UsageEventResponse\BatchIngestUsageEventResponse;
 use Chargebee\Responses\UsageEventResponse\CreateUsageEventResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -25,12 +24,10 @@ Interface UsageEventActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateUsageEventResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateUsageEventResponse;
 
@@ -48,12 +45,10 @@ Interface UsageEventActionsInterface
     *   @param array<string, string> $headers
     *   @return BatchIngestUsageEventResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function batchIngest(array $params, array $headers = []): BatchIngestUsageEventResponse;
 

--- a/src/Actions/Contracts/UsageEventActionsInterface.php
+++ b/src/Actions/Contracts/UsageEventActionsInterface.php
@@ -3,6 +3,12 @@ namespace Chargebee\Actions\Contracts;
     
 use Chargebee\Responses\UsageEventResponse\BatchIngestUsageEventResponse;
 use Chargebee\Responses\UsageEventResponse\CreateUsageEventResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface UsageEventActionsInterface
 {
@@ -18,6 +24,13 @@ Interface UsageEventActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateUsageEventResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateUsageEventResponse;
 
@@ -34,6 +47,13 @@ Interface UsageEventActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return BatchIngestUsageEventResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function batchIngest(array $params, array $headers = []): BatchIngestUsageEventResponse;
 

--- a/src/Actions/Contracts/UsageFileActionsInterface.php
+++ b/src/Actions/Contracts/UsageFileActionsInterface.php
@@ -4,7 +4,6 @@ namespace Chargebee\Actions\Contracts;
 use Chargebee\Responses\UsageFileResponse\UploadUrlUsageFileResponse;
 use Chargebee\Responses\UsageFileResponse\ProcessingStatusUsageFileResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -20,12 +19,10 @@ Interface UsageFileActionsInterface
     *   @param array<string, string> $headers
     *   @return ProcessingStatusUsageFileResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function processingStatus(string $id, array $headers = []): ProcessingStatusUsageFileResponse;
 
@@ -39,12 +36,10 @@ Interface UsageFileActionsInterface
     *   @param array<string, string> $headers
     *   @return UploadUrlUsageFileResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function uploadUrl(array $params, array $headers = []): UploadUrlUsageFileResponse;
 

--- a/src/Actions/Contracts/UsageFileActionsInterface.php
+++ b/src/Actions/Contracts/UsageFileActionsInterface.php
@@ -3,6 +3,12 @@ namespace Chargebee\Actions\Contracts;
     
 use Chargebee\Responses\UsageFileResponse\UploadUrlUsageFileResponse;
 use Chargebee\Responses\UsageFileResponse\ProcessingStatusUsageFileResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface UsageFileActionsInterface
 {
@@ -13,6 +19,13 @@ Interface UsageFileActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ProcessingStatusUsageFileResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function processingStatus(string $id, array $headers = []): ProcessingStatusUsageFileResponse;
 
@@ -25,6 +38,13 @@ Interface UsageFileActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return UploadUrlUsageFileResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function uploadUrl(array $params, array $headers = []): UploadUrlUsageFileResponse;
 

--- a/src/Actions/Contracts/VirtualBankAccountActionsInterface.php
+++ b/src/Actions/Contracts/VirtualBankAccountActionsInterface.php
@@ -9,7 +9,6 @@ use Chargebee\Responses\VirtualBankAccountResponse\ListVirtualBankAccountRespons
 use Chargebee\Responses\VirtualBankAccountResponse\CreateVirtualBankAccountResponse;
 use Chargebee\Responses\VirtualBankAccountResponse\DeleteLocalVirtualBankAccountResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -25,12 +24,10 @@ Interface VirtualBankAccountActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteLocalVirtualBankAccountResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function deleteLocal(string $id, array $headers = []): DeleteLocalVirtualBankAccountResponse;
 
@@ -41,12 +38,10 @@ Interface VirtualBankAccountActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteVirtualBankAccountResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteVirtualBankAccountResponse;
 
@@ -79,12 +74,10 @@ Interface VirtualBankAccountActionsInterface
     *   @param array<string, string> $headers
     *   @return ListVirtualBankAccountResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListVirtualBankAccountResponse;
 
@@ -99,12 +92,10 @@ Interface VirtualBankAccountActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateVirtualBankAccountResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateVirtualBankAccountResponse;
 
@@ -115,12 +106,10 @@ Interface VirtualBankAccountActionsInterface
     *   @param array<string, string> $headers
     *   @return SyncFundVirtualBankAccountResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function syncFund(string $id, array $headers = []): SyncFundVirtualBankAccountResponse;
 
@@ -131,12 +120,10 @@ Interface VirtualBankAccountActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveVirtualBankAccountResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveVirtualBankAccountResponse;
 
@@ -151,12 +138,10 @@ Interface VirtualBankAccountActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateUsingPermanentTokenVirtualBankAccountResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createUsingPermanentToken(array $params, array $headers = []): CreateUsingPermanentTokenVirtualBankAccountResponse;
 

--- a/src/Actions/Contracts/VirtualBankAccountActionsInterface.php
+++ b/src/Actions/Contracts/VirtualBankAccountActionsInterface.php
@@ -8,6 +8,12 @@ use Chargebee\Responses\VirtualBankAccountResponse\DeleteVirtualBankAccountRespo
 use Chargebee\Responses\VirtualBankAccountResponse\ListVirtualBankAccountResponse;
 use Chargebee\Responses\VirtualBankAccountResponse\CreateVirtualBankAccountResponse;
 use Chargebee\Responses\VirtualBankAccountResponse\DeleteLocalVirtualBankAccountResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface VirtualBankAccountActionsInterface
 {
@@ -18,6 +24,13 @@ Interface VirtualBankAccountActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteLocalVirtualBankAccountResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function deleteLocal(string $id, array $headers = []): DeleteLocalVirtualBankAccountResponse;
 
@@ -27,6 +40,13 @@ Interface VirtualBankAccountActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteVirtualBankAccountResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteVirtualBankAccountResponse;
 
@@ -58,6 +78,13 @@ Interface VirtualBankAccountActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListVirtualBankAccountResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListVirtualBankAccountResponse;
 
@@ -71,6 +98,13 @@ Interface VirtualBankAccountActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateVirtualBankAccountResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateVirtualBankAccountResponse;
 
@@ -80,6 +114,13 @@ Interface VirtualBankAccountActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return SyncFundVirtualBankAccountResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function syncFund(string $id, array $headers = []): SyncFundVirtualBankAccountResponse;
 
@@ -89,6 +130,13 @@ Interface VirtualBankAccountActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveVirtualBankAccountResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveVirtualBankAccountResponse;
 
@@ -102,6 +150,13 @@ Interface VirtualBankAccountActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateUsingPermanentTokenVirtualBankAccountResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createUsingPermanentToken(array $params, array $headers = []): CreateUsingPermanentTokenVirtualBankAccountResponse;
 

--- a/src/Actions/Contracts/WebhookEndpointActionsInterface.php
+++ b/src/Actions/Contracts/WebhookEndpointActionsInterface.php
@@ -6,6 +6,12 @@ use Chargebee\Responses\WebhookEndpointResponse\ListWebhookEndpointResponse;
 use Chargebee\Responses\WebhookEndpointResponse\RetrieveWebhookEndpointResponse;
 use Chargebee\Responses\WebhookEndpointResponse\DeleteWebhookEndpointResponse;
 use Chargebee\Responses\WebhookEndpointResponse\CreateWebhookEndpointResponse;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 Interface WebhookEndpointActionsInterface
 {
@@ -16,6 +22,13 @@ Interface WebhookEndpointActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteWebhookEndpointResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteWebhookEndpointResponse;
 
@@ -25,6 +38,13 @@ Interface WebhookEndpointActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveWebhookEndpointResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveWebhookEndpointResponse;
 
@@ -44,6 +64,13 @@ Interface WebhookEndpointActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateWebhookEndpointResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdateWebhookEndpointResponse;
 
@@ -56,6 +83,13 @@ Interface WebhookEndpointActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListWebhookEndpointResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListWebhookEndpointResponse;
 
@@ -76,6 +110,13 @@ Interface WebhookEndpointActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateWebhookEndpointResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateWebhookEndpointResponse;
 

--- a/src/Actions/Contracts/WebhookEndpointActionsInterface.php
+++ b/src/Actions/Contracts/WebhookEndpointActionsInterface.php
@@ -7,7 +7,6 @@ use Chargebee\Responses\WebhookEndpointResponse\RetrieveWebhookEndpointResponse;
 use Chargebee\Responses\WebhookEndpointResponse\DeleteWebhookEndpointResponse;
 use Chargebee\Responses\WebhookEndpointResponse\CreateWebhookEndpointResponse;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -23,12 +22,10 @@ Interface WebhookEndpointActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteWebhookEndpointResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteWebhookEndpointResponse;
 
@@ -39,12 +36,10 @@ Interface WebhookEndpointActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveWebhookEndpointResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveWebhookEndpointResponse;
 
@@ -65,12 +60,10 @@ Interface WebhookEndpointActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateWebhookEndpointResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdateWebhookEndpointResponse;
 
@@ -84,12 +77,10 @@ Interface WebhookEndpointActionsInterface
     *   @param array<string, string> $headers
     *   @return ListWebhookEndpointResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListWebhookEndpointResponse;
 
@@ -111,12 +102,10 @@ Interface WebhookEndpointActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateWebhookEndpointResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateWebhookEndpointResponse;
 

--- a/src/Actions/CouponActions.php
+++ b/src/Actions/CouponActions.php
@@ -17,6 +17,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class CouponActions implements CouponActionsInterface
 {
@@ -97,6 +103,13 @@ final class CouponActions implements CouponActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListCouponResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListCouponResponse
     {
@@ -147,6 +160,13 @@ final class CouponActions implements CouponActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateCouponResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateCouponResponse
     {
@@ -210,6 +230,13 @@ final class CouponActions implements CouponActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateForItemsCouponResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function updateForItems(string $id, array $params, array $headers = []): UpdateForItemsCouponResponse
     {
@@ -242,6 +269,13 @@ final class CouponActions implements CouponActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UnarchiveCouponResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function unarchive(string $id, array $headers = []): UnarchiveCouponResponse
     {
@@ -268,6 +302,13 @@ final class CouponActions implements CouponActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteCouponResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteCouponResponse
     {
@@ -299,6 +340,13 @@ final class CouponActions implements CouponActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CopyCouponResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function copy(array $params, array $headers = []): CopyCouponResponse
     {
@@ -326,6 +374,13 @@ final class CouponActions implements CouponActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveCouponResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveCouponResponse
     {
@@ -373,6 +428,13 @@ final class CouponActions implements CouponActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateCouponResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdateCouponResponse
     {
@@ -438,6 +500,13 @@ final class CouponActions implements CouponActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateForItemsCouponResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createForItems(array $params, array $headers = []): CreateForItemsCouponResponse
     {

--- a/src/Actions/CouponActions.php
+++ b/src/Actions/CouponActions.php
@@ -18,7 +18,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -104,12 +103,10 @@ final class CouponActions implements CouponActionsInterface
     *   @param array<string, string> $headers
     *   @return ListCouponResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListCouponResponse
     {
@@ -161,12 +158,10 @@ final class CouponActions implements CouponActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateCouponResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateCouponResponse
     {
@@ -231,12 +226,10 @@ final class CouponActions implements CouponActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateForItemsCouponResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function updateForItems(string $id, array $params, array $headers = []): UpdateForItemsCouponResponse
     {
@@ -270,12 +263,10 @@ final class CouponActions implements CouponActionsInterface
     *   @param array<string, string> $headers
     *   @return UnarchiveCouponResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function unarchive(string $id, array $headers = []): UnarchiveCouponResponse
     {
@@ -303,12 +294,10 @@ final class CouponActions implements CouponActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteCouponResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteCouponResponse
     {
@@ -341,12 +330,10 @@ final class CouponActions implements CouponActionsInterface
     *   @param array<string, string> $headers
     *   @return CopyCouponResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function copy(array $params, array $headers = []): CopyCouponResponse
     {
@@ -375,12 +362,10 @@ final class CouponActions implements CouponActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveCouponResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveCouponResponse
     {
@@ -429,12 +414,10 @@ final class CouponActions implements CouponActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateCouponResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdateCouponResponse
     {
@@ -501,12 +484,10 @@ final class CouponActions implements CouponActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateForItemsCouponResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createForItems(array $params, array $headers = []): CreateForItemsCouponResponse
     {

--- a/src/Actions/CouponCodeActions.php
+++ b/src/Actions/CouponCodeActions.php
@@ -12,6 +12,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class CouponCodeActions implements CouponCodeActionsInterface
 {
@@ -56,6 +62,13 @@ final class CouponCodeActions implements CouponCodeActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListCouponCodeResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListCouponCodeResponse
     {
@@ -86,6 +99,13 @@ final class CouponCodeActions implements CouponCodeActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateCouponCodeResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateCouponCodeResponse
     {
@@ -113,6 +133,13 @@ final class CouponCodeActions implements CouponCodeActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveCouponCodeResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveCouponCodeResponse
     {
@@ -138,6 +165,13 @@ final class CouponCodeActions implements CouponCodeActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ArchiveCouponCodeResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function archive(string $id, array $headers = []): ArchiveCouponCodeResponse
     {

--- a/src/Actions/CouponCodeActions.php
+++ b/src/Actions/CouponCodeActions.php
@@ -13,7 +13,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -63,12 +62,10 @@ final class CouponCodeActions implements CouponCodeActionsInterface
     *   @param array<string, string> $headers
     *   @return ListCouponCodeResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListCouponCodeResponse
     {
@@ -100,12 +97,10 @@ final class CouponCodeActions implements CouponCodeActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateCouponCodeResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateCouponCodeResponse
     {
@@ -134,12 +129,10 @@ final class CouponCodeActions implements CouponCodeActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveCouponCodeResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveCouponCodeResponse
     {
@@ -166,12 +159,10 @@ final class CouponCodeActions implements CouponCodeActionsInterface
     *   @param array<string, string> $headers
     *   @return ArchiveCouponCodeResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function archive(string $id, array $headers = []): ArchiveCouponCodeResponse
     {

--- a/src/Actions/CouponSetActions.php
+++ b/src/Actions/CouponSetActions.php
@@ -15,6 +15,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class CouponSetActions implements CouponSetActionsInterface
 {
@@ -82,6 +88,13 @@ final class CouponSetActions implements CouponSetActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListCouponSetResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListCouponSetResponse
     {
@@ -113,6 +126,13 @@ final class CouponSetActions implements CouponSetActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateCouponSetResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateCouponSetResponse
     {
@@ -144,6 +164,13 @@ final class CouponSetActions implements CouponSetActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateCouponSetResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdateCouponSetResponse
     {
@@ -172,6 +199,13 @@ final class CouponSetActions implements CouponSetActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveCouponSetResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveCouponSetResponse
     {
@@ -199,6 +233,13 @@ final class CouponSetActions implements CouponSetActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return AddCouponCodesCouponSetResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function addCouponCodes(string $id, array $params = [], array $headers = []): AddCouponCodesCouponSetResponse
     {
@@ -226,6 +267,13 @@ final class CouponSetActions implements CouponSetActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteUnusedCouponCodesCouponSetResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function deleteUnusedCouponCodes(string $id, array $headers = []): DeleteUnusedCouponCodesCouponSetResponse
     {
@@ -252,6 +300,13 @@ final class CouponSetActions implements CouponSetActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteCouponSetResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteCouponSetResponse
     {

--- a/src/Actions/CouponSetActions.php
+++ b/src/Actions/CouponSetActions.php
@@ -16,7 +16,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -89,12 +88,10 @@ final class CouponSetActions implements CouponSetActionsInterface
     *   @param array<string, string> $headers
     *   @return ListCouponSetResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListCouponSetResponse
     {
@@ -127,12 +124,10 @@ final class CouponSetActions implements CouponSetActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateCouponSetResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateCouponSetResponse
     {
@@ -165,12 +160,10 @@ final class CouponSetActions implements CouponSetActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateCouponSetResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdateCouponSetResponse
     {
@@ -200,12 +193,10 @@ final class CouponSetActions implements CouponSetActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveCouponSetResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveCouponSetResponse
     {
@@ -234,12 +225,10 @@ final class CouponSetActions implements CouponSetActionsInterface
     *   @param array<string, string> $headers
     *   @return AddCouponCodesCouponSetResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function addCouponCodes(string $id, array $params = [], array $headers = []): AddCouponCodesCouponSetResponse
     {
@@ -268,12 +257,10 @@ final class CouponSetActions implements CouponSetActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteUnusedCouponCodesCouponSetResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function deleteUnusedCouponCodes(string $id, array $headers = []): DeleteUnusedCouponCodesCouponSetResponse
     {
@@ -301,12 +288,10 @@ final class CouponSetActions implements CouponSetActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteCouponSetResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteCouponSetResponse
     {

--- a/src/Actions/CreditNoteActions.php
+++ b/src/Actions/CreditNoteActions.php
@@ -23,7 +23,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -47,12 +46,10 @@ final class CreditNoteActions implements CreditNoteActionsInterface
     *   @param array<string, string> $headers
     *   @return VoidCreditNoteCreditNoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function voidCreditNote(string $id, array $params = [], array $headers = []): VoidCreditNoteCreditNoteResponse
     {
@@ -85,12 +82,10 @@ final class CreditNoteActions implements CreditNoteActionsInterface
     *   @param array<string, string> $headers
     *   @return RefundCreditNoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function refund(string $id, array $params = [], array $headers = []): RefundCreditNoteResponse
     {
@@ -256,12 +251,10 @@ final class CreditNoteActions implements CreditNoteActionsInterface
     *   @param array<string, string> $headers
     *   @return ListCreditNoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListCreditNoteResponse
     {
@@ -313,12 +306,10 @@ final class CreditNoteActions implements CreditNoteActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateCreditNoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateCreditNoteResponse
     {
@@ -358,12 +349,10 @@ final class CreditNoteActions implements CreditNoteActionsInterface
     *   @param array<string, string> $headers
     *   @return RecordRefundCreditNoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function recordRefund(string $id, array $params, array $headers = []): RecordRefundCreditNoteResponse
     {
@@ -487,12 +476,10 @@ final class CreditNoteActions implements CreditNoteActionsInterface
     *   @param array<string, string> $headers
     *   @return ImportCreditNoteCreditNoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function importCreditNote(array $params, array $headers = []): ImportCreditNoteCreditNoteResponse
     {
@@ -523,12 +510,10 @@ final class CreditNoteActions implements CreditNoteActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteCreditNoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $params = [], array $headers = []): DeleteCreditNoteResponse
     {
@@ -560,12 +545,10 @@ final class CreditNoteActions implements CreditNoteActionsInterface
     *   @param array<string, string> $headers
     *   @return CreditNotesForCustomerCreditNoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function creditNotesForCustomer(string $id, array $params = [], array $headers = []): CreditNotesForCustomerCreditNoteResponse
     {
@@ -593,12 +576,10 @@ final class CreditNoteActions implements CreditNoteActionsInterface
     *   @param array<string, string> $headers
     *   @return DownloadEinvoiceCreditNoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function downloadEinvoice(string $id, array $headers = []): DownloadEinvoiceCreditNoteResponse
     {
@@ -627,12 +608,10 @@ final class CreditNoteActions implements CreditNoteActionsInterface
     *   @param array<string, string> $headers
     *   @return PdfCreditNoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function pdf(string $id, array $params = [], array $headers = []): PdfCreditNoteResponse
     {
@@ -661,12 +640,10 @@ final class CreditNoteActions implements CreditNoteActionsInterface
     *   @param array<string, string> $headers
     *   @return ResendEinvoiceCreditNoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function resendEinvoice(string $id, array $headers = []): ResendEinvoiceCreditNoteResponse
     {
@@ -698,12 +675,10 @@ final class CreditNoteActions implements CreditNoteActionsInterface
     *   @param array<string, string> $headers
     *   @return RemoveTaxWithheldRefundCreditNoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function removeTaxWithheldRefund(string $id, array $params, array $headers = []): RemoveTaxWithheldRefundCreditNoteResponse
     {
@@ -741,12 +716,10 @@ final class CreditNoteActions implements CreditNoteActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveCreditNoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $params = [], array $headers = []): RetrieveCreditNoteResponse
     {
@@ -774,12 +747,10 @@ final class CreditNoteActions implements CreditNoteActionsInterface
     *   @param array<string, string> $headers
     *   @return SendEinvoiceCreditNoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function sendEinvoice(string $id, array $headers = []): SendEinvoiceCreditNoteResponse
     {

--- a/src/Actions/CreditNoteActions.php
+++ b/src/Actions/CreditNoteActions.php
@@ -22,6 +22,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class CreditNoteActions implements CreditNoteActionsInterface
 {
@@ -40,6 +46,13 @@ final class CreditNoteActions implements CreditNoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return VoidCreditNoteCreditNoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function voidCreditNote(string $id, array $params = [], array $headers = []): VoidCreditNoteCreditNoteResponse
     {
@@ -71,6 +84,13 @@ final class CreditNoteActions implements CreditNoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RefundCreditNoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function refund(string $id, array $params = [], array $headers = []): RefundCreditNoteResponse
     {
@@ -235,6 +255,13 @@ final class CreditNoteActions implements CreditNoteActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListCreditNoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListCreditNoteResponse
     {
@@ -285,6 +312,13 @@ final class CreditNoteActions implements CreditNoteActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateCreditNoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateCreditNoteResponse
     {
@@ -323,6 +357,13 @@ final class CreditNoteActions implements CreditNoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RecordRefundCreditNoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function recordRefund(string $id, array $params, array $headers = []): RecordRefundCreditNoteResponse
     {
@@ -445,6 +486,13 @@ final class CreditNoteActions implements CreditNoteActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ImportCreditNoteCreditNoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function importCreditNote(array $params, array $headers = []): ImportCreditNoteCreditNoteResponse
     {
@@ -474,6 +522,13 @@ final class CreditNoteActions implements CreditNoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteCreditNoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $params = [], array $headers = []): DeleteCreditNoteResponse
     {
@@ -504,6 +559,13 @@ final class CreditNoteActions implements CreditNoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CreditNotesForCustomerCreditNoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function creditNotesForCustomer(string $id, array $params = [], array $headers = []): CreditNotesForCustomerCreditNoteResponse
     {
@@ -530,6 +592,13 @@ final class CreditNoteActions implements CreditNoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DownloadEinvoiceCreditNoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function downloadEinvoice(string $id, array $headers = []): DownloadEinvoiceCreditNoteResponse
     {
@@ -557,6 +626,13 @@ final class CreditNoteActions implements CreditNoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return PdfCreditNoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function pdf(string $id, array $params = [], array $headers = []): PdfCreditNoteResponse
     {
@@ -584,6 +660,13 @@ final class CreditNoteActions implements CreditNoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ResendEinvoiceCreditNoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function resendEinvoice(string $id, array $headers = []): ResendEinvoiceCreditNoteResponse
     {
@@ -614,6 +697,13 @@ final class CreditNoteActions implements CreditNoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RemoveTaxWithheldRefundCreditNoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function removeTaxWithheldRefund(string $id, array $params, array $headers = []): RemoveTaxWithheldRefundCreditNoteResponse
     {
@@ -650,6 +740,13 @@ final class CreditNoteActions implements CreditNoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveCreditNoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $params = [], array $headers = []): RetrieveCreditNoteResponse
     {
@@ -676,6 +773,13 @@ final class CreditNoteActions implements CreditNoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return SendEinvoiceCreditNoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function sendEinvoice(string $id, array $headers = []): SendEinvoiceCreditNoteResponse
     {

--- a/src/Actions/CurrencyActions.php
+++ b/src/Actions/CurrencyActions.php
@@ -13,6 +13,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class CurrencyActions implements CurrencyActionsInterface
 {
@@ -32,6 +38,13 @@ final class CurrencyActions implements CurrencyActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return AddScheduleCurrencyResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function addSchedule(string $id, array $params, array $headers = []): AddScheduleCurrencyResponse
     {
@@ -63,6 +76,13 @@ final class CurrencyActions implements CurrencyActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateCurrencyResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateCurrencyResponse
     {
@@ -90,6 +110,13 @@ final class CurrencyActions implements CurrencyActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveCurrencyResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveCurrencyResponse
     {
@@ -118,6 +145,13 @@ final class CurrencyActions implements CurrencyActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateCurrencyResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params, array $headers = []): UpdateCurrencyResponse
     {
@@ -145,6 +179,13 @@ final class CurrencyActions implements CurrencyActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RemoveScheduleCurrencyResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function removeSchedule(string $id, array $headers = []): RemoveScheduleCurrencyResponse
     {
@@ -171,6 +212,13 @@ final class CurrencyActions implements CurrencyActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListCurrencyResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $headers = []): ListCurrencyResponse
     {

--- a/src/Actions/CurrencyActions.php
+++ b/src/Actions/CurrencyActions.php
@@ -14,7 +14,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -39,12 +38,10 @@ final class CurrencyActions implements CurrencyActionsInterface
     *   @param array<string, string> $headers
     *   @return AddScheduleCurrencyResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function addSchedule(string $id, array $params, array $headers = []): AddScheduleCurrencyResponse
     {
@@ -77,12 +74,10 @@ final class CurrencyActions implements CurrencyActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateCurrencyResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateCurrencyResponse
     {
@@ -111,12 +106,10 @@ final class CurrencyActions implements CurrencyActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveCurrencyResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveCurrencyResponse
     {
@@ -146,12 +139,10 @@ final class CurrencyActions implements CurrencyActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateCurrencyResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params, array $headers = []): UpdateCurrencyResponse
     {
@@ -180,12 +171,10 @@ final class CurrencyActions implements CurrencyActionsInterface
     *   @param array<string, string> $headers
     *   @return RemoveScheduleCurrencyResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function removeSchedule(string $id, array $headers = []): RemoveScheduleCurrencyResponse
     {
@@ -213,12 +202,10 @@ final class CurrencyActions implements CurrencyActionsInterface
     *   @param array<string, string> $headers
     *   @return ListCurrencyResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $headers = []): ListCurrencyResponse
     {

--- a/src/Actions/CustomerActions.php
+++ b/src/Actions/CustomerActions.php
@@ -35,7 +35,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -59,12 +58,10 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $params = [], array $headers = []): DeleteCustomerResponse
     {
@@ -99,12 +96,10 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return AddPromotionalCreditsCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function addPromotionalCredits(string $id, array $params, array $headers = []): AddPromotionalCreditsCustomerResponse
     {
@@ -152,12 +147,10 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return RelationshipsCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function relationships(string $id, array $params = [], array $headers = []): RelationshipsCustomerResponse
     {
@@ -186,12 +179,10 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteRelationshipCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function deleteRelationship(string $id, array $headers = []): DeleteRelationshipCustomerResponse
     {
@@ -223,12 +214,10 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteContactCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function deleteContact(string $id, array $params, array $headers = []): DeleteContactCustomerResponse
     {
@@ -260,12 +249,10 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return AssignPaymentRoleCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function assignPaymentRole(string $id, array $params, array $headers = []): AssignPaymentRoleCustomerResponse
     {
@@ -297,12 +284,10 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return MoveCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function move(array $params, array $headers = []): MoveCustomerResponse
     {
@@ -333,12 +318,10 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return HierarchyCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function hierarchy(string $id, array $params, array $headers = []): HierarchyCustomerResponse
     {
@@ -376,12 +359,10 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdatePaymentMethodCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function updatePaymentMethod(string $id, array $params, array $headers = []): UpdatePaymentMethodCustomerResponse
     {
@@ -411,12 +392,10 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveCustomerResponse
     {
@@ -472,12 +451,10 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdateCustomerResponse
     {
@@ -512,12 +489,10 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return ListHierarchyDetailCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function listHierarchyDetail(string $id, array $params, array $headers = []): ListHierarchyDetailCustomerResponse
     {
@@ -551,12 +526,10 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return ChangeBillingDateCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function changeBillingDate(string $id, array $params = [], array $headers = []): ChangeBillingDateCustomerResponse
     {
@@ -689,12 +662,10 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return ListCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListCustomerResponse
     {
@@ -842,12 +813,10 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params = [], array $headers = []): CreateCustomerResponse
     {
@@ -892,12 +861,10 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return AddContactCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function addContact(string $id, array $params, array $headers = []): AddContactCustomerResponse
     {
@@ -929,12 +896,10 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return ContactsForCustomerCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function contactsForCustomer(string $id, array $params = [], array $headers = []): ContactsForCustomerCustomerResponse
     {
@@ -968,12 +933,10 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return DeductPromotionalCreditsCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function deductPromotionalCredits(string $id, array $params, array $headers = []): DeductPromotionalCreditsCustomerResponse
     {
@@ -1002,12 +965,10 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return ClearPersonalDataCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function clearPersonalData(string $id, array $headers = []): ClearPersonalDataCustomerResponse
     {
@@ -1038,12 +999,10 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return MergeCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function merge(array $params, array $headers = []): MergeCustomerResponse
     {
@@ -1117,12 +1076,10 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return CollectPaymentCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function collectPayment(string $id, array $params, array $headers = []): CollectPaymentCustomerResponse
     {
@@ -1163,12 +1120,10 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return RecordExcessPaymentCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function recordExcessPayment(string $id, array $params, array $headers = []): RecordExcessPaymentCustomerResponse
     {
@@ -1203,12 +1158,10 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return SetPromotionalCreditsCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function setPromotionalCredits(string $id, array $params, array $headers = []): SetPromotionalCreditsCustomerResponse
     {
@@ -1249,12 +1202,10 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateContactCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function updateContact(string $id, array $params, array $headers = []): UpdateContactCustomerResponse
     {
@@ -1299,12 +1250,10 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateHierarchySettingsCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function updateHierarchySettings(string $id, array $params = [], array $headers = []): UpdateHierarchySettingsCustomerResponse
     {
@@ -1370,12 +1319,10 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateBillingInfoCustomerResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function updateBillingInfo(string $id, array $params = [], array $headers = []): UpdateBillingInfoCustomerResponse
     {

--- a/src/Actions/CustomerActions.php
+++ b/src/Actions/CustomerActions.php
@@ -34,6 +34,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class CustomerActions implements CustomerActionsInterface
 {
@@ -52,6 +58,13 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $params = [], array $headers = []): DeleteCustomerResponse
     {
@@ -85,6 +98,13 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return AddPromotionalCreditsCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function addPromotionalCredits(string $id, array $params, array $headers = []): AddPromotionalCreditsCustomerResponse
     {
@@ -131,6 +151,13 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RelationshipsCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function relationships(string $id, array $params = [], array $headers = []): RelationshipsCustomerResponse
     {
@@ -158,6 +185,13 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteRelationshipCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function deleteRelationship(string $id, array $headers = []): DeleteRelationshipCustomerResponse
     {
@@ -188,6 +222,13 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteContactCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function deleteContact(string $id, array $params, array $headers = []): DeleteContactCustomerResponse
     {
@@ -218,6 +259,13 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return AssignPaymentRoleCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function assignPaymentRole(string $id, array $params, array $headers = []): AssignPaymentRoleCustomerResponse
     {
@@ -248,6 +296,13 @@ final class CustomerActions implements CustomerActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return MoveCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function move(array $params, array $headers = []): MoveCustomerResponse
     {
@@ -277,6 +332,13 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return HierarchyCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function hierarchy(string $id, array $params, array $headers = []): HierarchyCustomerResponse
     {
@@ -313,6 +375,13 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdatePaymentMethodCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function updatePaymentMethod(string $id, array $params, array $headers = []): UpdatePaymentMethodCustomerResponse
     {
@@ -341,6 +410,13 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveCustomerResponse
     {
@@ -395,6 +471,13 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdateCustomerResponse
     {
@@ -428,6 +511,13 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ListHierarchyDetailCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function listHierarchyDetail(string $id, array $params, array $headers = []): ListHierarchyDetailCustomerResponse
     {
@@ -460,6 +550,13 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ChangeBillingDateCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function changeBillingDate(string $id, array $params = [], array $headers = []): ChangeBillingDateCustomerResponse
     {
@@ -591,6 +688,13 @@ final class CustomerActions implements CustomerActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListCustomerResponse
     {
@@ -737,6 +841,13 @@ final class CustomerActions implements CustomerActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params = [], array $headers = []): CreateCustomerResponse
     {
@@ -780,6 +891,13 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return AddContactCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function addContact(string $id, array $params, array $headers = []): AddContactCustomerResponse
     {
@@ -810,6 +928,13 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ContactsForCustomerCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function contactsForCustomer(string $id, array $params = [], array $headers = []): ContactsForCustomerCustomerResponse
     {
@@ -842,6 +967,13 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeductPromotionalCreditsCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function deductPromotionalCredits(string $id, array $params, array $headers = []): DeductPromotionalCreditsCustomerResponse
     {
@@ -869,6 +1001,13 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ClearPersonalDataCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function clearPersonalData(string $id, array $headers = []): ClearPersonalDataCustomerResponse
     {
@@ -898,6 +1037,13 @@ final class CustomerActions implements CustomerActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return MergeCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function merge(array $params, array $headers = []): MergeCustomerResponse
     {
@@ -970,6 +1116,13 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CollectPaymentCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function collectPayment(string $id, array $params, array $headers = []): CollectPaymentCustomerResponse
     {
@@ -1009,6 +1162,13 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RecordExcessPaymentCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function recordExcessPayment(string $id, array $params, array $headers = []): RecordExcessPaymentCustomerResponse
     {
@@ -1042,6 +1202,13 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return SetPromotionalCreditsCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function setPromotionalCredits(string $id, array $params, array $headers = []): SetPromotionalCreditsCustomerResponse
     {
@@ -1081,6 +1248,13 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateContactCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function updateContact(string $id, array $params, array $headers = []): UpdateContactCustomerResponse
     {
@@ -1124,6 +1298,13 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateHierarchySettingsCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function updateHierarchySettings(string $id, array $params = [], array $headers = []): UpdateHierarchySettingsCustomerResponse
     {
@@ -1188,6 +1369,13 @@ final class CustomerActions implements CustomerActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateBillingInfoCustomerResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function updateBillingInfo(string $id, array $params = [], array $headers = []): UpdateBillingInfoCustomerResponse
     {

--- a/src/Actions/CustomerEntitlementActions.php
+++ b/src/Actions/CustomerEntitlementActions.php
@@ -9,6 +9,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class CustomerEntitlementActions implements CustomerEntitlementActionsInterface
 {
@@ -29,6 +35,13 @@ final class CustomerEntitlementActions implements CustomerEntitlementActionsInte
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return EntitlementsForCustomerCustomerEntitlementResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function entitlementsForCustomer(string $id, array $params = [], array $headers = []): EntitlementsForCustomerCustomerEntitlementResponse
     {

--- a/src/Actions/CustomerEntitlementActions.php
+++ b/src/Actions/CustomerEntitlementActions.php
@@ -10,7 +10,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -36,12 +35,10 @@ final class CustomerEntitlementActions implements CustomerEntitlementActionsInte
     *   @param array<string, string> $headers
     *   @return EntitlementsForCustomerCustomerEntitlementResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function entitlementsForCustomer(string $id, array $params = [], array $headers = []): EntitlementsForCustomerCustomerEntitlementResponse
     {

--- a/src/Actions/DifferentialPriceActions.php
+++ b/src/Actions/DifferentialPriceActions.php
@@ -13,6 +13,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class DifferentialPriceActions implements DifferentialPriceActionsInterface
 {
@@ -31,6 +37,13 @@ final class DifferentialPriceActions implements DifferentialPriceActionsInterfac
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteDifferentialPriceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $params, array $headers = []): DeleteDifferentialPriceResponse
     {
@@ -77,6 +90,13 @@ final class DifferentialPriceActions implements DifferentialPriceActionsInterfac
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CreateDifferentialPriceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(string $id, array $params, array $headers = []): CreateDifferentialPriceResponse
     {
@@ -136,6 +156,13 @@ final class DifferentialPriceActions implements DifferentialPriceActionsInterfac
     *   
     *   @param array<string, string> $headers
     *   @return ListDifferentialPriceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListDifferentialPriceResponse
     {
@@ -164,6 +191,13 @@ final class DifferentialPriceActions implements DifferentialPriceActionsInterfac
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveDifferentialPriceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $params, array $headers = []): RetrieveDifferentialPriceResponse
     {
@@ -208,6 +242,13 @@ final class DifferentialPriceActions implements DifferentialPriceActionsInterfac
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateDifferentialPriceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params, array $headers = []): UpdateDifferentialPriceResponse
     {

--- a/src/Actions/DifferentialPriceActions.php
+++ b/src/Actions/DifferentialPriceActions.php
@@ -14,7 +14,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -38,12 +37,10 @@ final class DifferentialPriceActions implements DifferentialPriceActionsInterfac
     *   @param array<string, string> $headers
     *   @return DeleteDifferentialPriceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $params, array $headers = []): DeleteDifferentialPriceResponse
     {
@@ -91,12 +88,10 @@ final class DifferentialPriceActions implements DifferentialPriceActionsInterfac
     *   @param array<string, string> $headers
     *   @return CreateDifferentialPriceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(string $id, array $params, array $headers = []): CreateDifferentialPriceResponse
     {
@@ -157,12 +152,10 @@ final class DifferentialPriceActions implements DifferentialPriceActionsInterfac
     *   @param array<string, string> $headers
     *   @return ListDifferentialPriceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListDifferentialPriceResponse
     {
@@ -192,12 +185,10 @@ final class DifferentialPriceActions implements DifferentialPriceActionsInterfac
     *   @param array<string, string> $headers
     *   @return RetrieveDifferentialPriceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $params, array $headers = []): RetrieveDifferentialPriceResponse
     {
@@ -243,12 +234,10 @@ final class DifferentialPriceActions implements DifferentialPriceActionsInterfac
     *   @param array<string, string> $headers
     *   @return UpdateDifferentialPriceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params, array $headers = []): UpdateDifferentialPriceResponse
     {

--- a/src/Actions/EntitlementActions.php
+++ b/src/Actions/EntitlementActions.php
@@ -10,6 +10,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class EntitlementActions implements EntitlementActionsInterface
 {
@@ -26,16 +32,16 @@ final class EntitlementActions implements EntitlementActionsInterface
     *     limit?: int,
     *     offset?: string,
     *     feature_id?: array{
-    *     is?: mixed,
     *     in?: mixed,
+    *     is?: mixed,
     *     },
     * entity_type?: array{
-    *     is?: mixed,
     *     in?: mixed,
+    *     is?: mixed,
     *     },
     * entity_id?: array{
-    *     is?: mixed,
     *     in?: mixed,
+    *     is?: mixed,
     *     },
     * include_drafts?: bool,
     *     embed?: string,
@@ -43,6 +49,13 @@ final class EntitlementActions implements EntitlementActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListEntitlementResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListEntitlementResponse
     {
@@ -79,6 +92,13 @@ final class EntitlementActions implements EntitlementActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateEntitlementResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateEntitlementResponse
     {

--- a/src/Actions/EntitlementActions.php
+++ b/src/Actions/EntitlementActions.php
@@ -11,7 +11,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -50,12 +49,10 @@ final class EntitlementActions implements EntitlementActionsInterface
     *   @param array<string, string> $headers
     *   @return ListEntitlementResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListEntitlementResponse
     {
@@ -93,12 +90,10 @@ final class EntitlementActions implements EntitlementActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateEntitlementResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateEntitlementResponse
     {

--- a/src/Actions/EntitlementOverrideActions.php
+++ b/src/Actions/EntitlementOverrideActions.php
@@ -10,6 +10,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class EntitlementOverrideActions implements EntitlementOverrideActionsInterface
 {
@@ -32,6 +38,13 @@ final class EntitlementOverrideActions implements EntitlementOverrideActionsInte
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ListEntitlementOverrideForSubscriptionEntitlementOverrideResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function listEntitlementOverrideForSubscription(string $id, array $params = [], array $headers = []): ListEntitlementOverrideForSubscriptionEntitlementOverrideResponse
     {
@@ -66,6 +79,13 @@ final class EntitlementOverrideActions implements EntitlementOverrideActionsInte
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return AddEntitlementOverrideForSubscriptionEntitlementOverrideResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function addEntitlementOverrideForSubscription(string $id, array $params, array $headers = []): AddEntitlementOverrideForSubscriptionEntitlementOverrideResponse
     {

--- a/src/Actions/EntitlementOverrideActions.php
+++ b/src/Actions/EntitlementOverrideActions.php
@@ -11,7 +11,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -39,12 +38,10 @@ final class EntitlementOverrideActions implements EntitlementOverrideActionsInte
     *   @param array<string, string> $headers
     *   @return ListEntitlementOverrideForSubscriptionEntitlementOverrideResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function listEntitlementOverrideForSubscription(string $id, array $params = [], array $headers = []): ListEntitlementOverrideForSubscriptionEntitlementOverrideResponse
     {
@@ -80,12 +77,10 @@ final class EntitlementOverrideActions implements EntitlementOverrideActionsInte
     *   @param array<string, string> $headers
     *   @return AddEntitlementOverrideForSubscriptionEntitlementOverrideResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function addEntitlementOverrideForSubscription(string $id, array $params, array $headers = []): AddEntitlementOverrideForSubscriptionEntitlementOverrideResponse
     {

--- a/src/Actions/EstimateActions.php
+++ b/src/Actions/EstimateActions.php
@@ -27,6 +27,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class EstimateActions implements EstimateActionsInterface
 {
@@ -48,6 +54,13 @@ final class EstimateActions implements EstimateActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RenewalEstimateEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function renewalEstimate(string $id, array $params = [], array $headers = []): RenewalEstimateEstimateResponse
     {
@@ -170,6 +183,13 @@ final class EstimateActions implements EstimateActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateSubItemEstimateEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createSubItemEstimate(array $params, array $headers = []): CreateSubItemEstimateEstimateResponse
     {
@@ -203,6 +223,13 @@ final class EstimateActions implements EstimateActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return PaymentSchedulesEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function paymentSchedules(array $params, array $headers = []): PaymentSchedulesEstimateResponse
     {
@@ -249,6 +276,13 @@ final class EstimateActions implements EstimateActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CancelSubscriptionForItemsEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function cancelSubscriptionForItems(string $id, array $params = [], array $headers = []): CancelSubscriptionForItemsEstimateResponse
     {
@@ -282,6 +316,13 @@ final class EstimateActions implements EstimateActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ResumeSubscriptionEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function resumeSubscription(string $id, array $params = [], array $headers = []): ResumeSubscriptionEstimateResponse
     {
@@ -401,6 +442,13 @@ final class EstimateActions implements EstimateActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateInvoiceForItemsEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createInvoiceForItems(array $params, array $headers = []): CreateInvoiceForItemsEstimateResponse
     {
@@ -478,6 +526,13 @@ final class EstimateActions implements EstimateActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return GiftSubscriptionForItemsEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function giftSubscriptionForItems(array $params, array $headers = []): GiftSubscriptionForItemsEstimateResponse
     {
@@ -607,6 +662,13 @@ final class EstimateActions implements EstimateActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return UpdateSubscriptionForItemsEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function updateSubscriptionForItems(array $params, array $headers = []): UpdateSubscriptionForItemsEstimateResponse
     {
@@ -634,6 +696,13 @@ final class EstimateActions implements EstimateActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpcomingInvoicesEstimateEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function upcomingInvoicesEstimate(string $id, array $headers = []): UpcomingInvoicesEstimateEstimateResponse
     {
@@ -664,6 +733,13 @@ final class EstimateActions implements EstimateActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RegenerateInvoiceEstimateEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function regenerateInvoiceEstimate(string $id, array $params = [], array $headers = []): RegenerateInvoiceEstimateEstimateResponse
     {
@@ -775,6 +851,13 @@ final class EstimateActions implements EstimateActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CreateSubItemForCustomerEstimateEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createSubItemForCustomerEstimate(string $id, array $params, array $headers = []): CreateSubItemForCustomerEstimateEstimateResponse
     {
@@ -806,6 +889,13 @@ final class EstimateActions implements EstimateActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ChangeTermEndEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function changeTermEnd(string $id, array $params, array $headers = []): ChangeTermEndEstimateResponse
     {
@@ -841,6 +931,13 @@ final class EstimateActions implements EstimateActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return PauseSubscriptionEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function pauseSubscription(string $id, array $params = [], array $headers = []): PauseSubscriptionEstimateResponse
     {
@@ -882,6 +979,13 @@ final class EstimateActions implements EstimateActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return AdvanceInvoiceEstimateEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function advanceInvoiceEstimate(string $id, array $params = [], array $headers = []): AdvanceInvoiceEstimateEstimateResponse
     {
@@ -992,6 +1096,13 @@ final class EstimateActions implements EstimateActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return UpdateSubscriptionEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function updateSubscription(array $params, array $headers = []): UpdateSubscriptionEstimateResponse
     {
@@ -1074,6 +1185,13 @@ final class EstimateActions implements EstimateActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return GiftSubscriptionEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function giftSubscription(array $params, array $headers = []): GiftSubscriptionEstimateResponse
     {
@@ -1161,6 +1279,13 @@ final class EstimateActions implements EstimateActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CreateSubForCustomerEstimateEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createSubForCustomerEstimate(string $id, array $params, array $headers = []): CreateSubForCustomerEstimateEstimateResponse
     {
@@ -1272,6 +1397,13 @@ final class EstimateActions implements EstimateActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateSubscriptionEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createSubscription(array $params, array $headers = []): CreateSubscriptionEstimateResponse
     {
@@ -1364,6 +1496,13 @@ final class EstimateActions implements EstimateActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateInvoiceEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createInvoice(array $params = [], array $headers = []): CreateInvoiceEstimateResponse
     {
@@ -1408,6 +1547,13 @@ final class EstimateActions implements EstimateActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CancelSubscriptionEstimateResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function cancelSubscription(string $id, array $params = [], array $headers = []): CancelSubscriptionEstimateResponse
     {

--- a/src/Actions/EstimateActions.php
+++ b/src/Actions/EstimateActions.php
@@ -28,7 +28,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -55,12 +54,10 @@ final class EstimateActions implements EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return RenewalEstimateEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function renewalEstimate(string $id, array $params = [], array $headers = []): RenewalEstimateEstimateResponse
     {
@@ -184,12 +181,10 @@ final class EstimateActions implements EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateSubItemEstimateEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createSubItemEstimate(array $params, array $headers = []): CreateSubItemEstimateEstimateResponse
     {
@@ -224,12 +219,10 @@ final class EstimateActions implements EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return PaymentSchedulesEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function paymentSchedules(array $params, array $headers = []): PaymentSchedulesEstimateResponse
     {
@@ -277,12 +270,10 @@ final class EstimateActions implements EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return CancelSubscriptionForItemsEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function cancelSubscriptionForItems(string $id, array $params = [], array $headers = []): CancelSubscriptionForItemsEstimateResponse
     {
@@ -317,12 +308,10 @@ final class EstimateActions implements EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return ResumeSubscriptionEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function resumeSubscription(string $id, array $params = [], array $headers = []): ResumeSubscriptionEstimateResponse
     {
@@ -443,12 +432,10 @@ final class EstimateActions implements EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateInvoiceForItemsEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createInvoiceForItems(array $params, array $headers = []): CreateInvoiceForItemsEstimateResponse
     {
@@ -527,12 +514,10 @@ final class EstimateActions implements EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return GiftSubscriptionForItemsEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function giftSubscriptionForItems(array $params, array $headers = []): GiftSubscriptionForItemsEstimateResponse
     {
@@ -663,12 +648,10 @@ final class EstimateActions implements EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateSubscriptionForItemsEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function updateSubscriptionForItems(array $params, array $headers = []): UpdateSubscriptionForItemsEstimateResponse
     {
@@ -697,12 +680,10 @@ final class EstimateActions implements EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return UpcomingInvoicesEstimateEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function upcomingInvoicesEstimate(string $id, array $headers = []): UpcomingInvoicesEstimateEstimateResponse
     {
@@ -734,12 +715,10 @@ final class EstimateActions implements EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return RegenerateInvoiceEstimateEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function regenerateInvoiceEstimate(string $id, array $params = [], array $headers = []): RegenerateInvoiceEstimateEstimateResponse
     {
@@ -852,12 +831,10 @@ final class EstimateActions implements EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateSubItemForCustomerEstimateEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createSubItemForCustomerEstimate(string $id, array $params, array $headers = []): CreateSubItemForCustomerEstimateEstimateResponse
     {
@@ -890,12 +867,10 @@ final class EstimateActions implements EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return ChangeTermEndEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function changeTermEnd(string $id, array $params, array $headers = []): ChangeTermEndEstimateResponse
     {
@@ -932,12 +907,10 @@ final class EstimateActions implements EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return PauseSubscriptionEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function pauseSubscription(string $id, array $params = [], array $headers = []): PauseSubscriptionEstimateResponse
     {
@@ -980,12 +953,10 @@ final class EstimateActions implements EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return AdvanceInvoiceEstimateEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function advanceInvoiceEstimate(string $id, array $params = [], array $headers = []): AdvanceInvoiceEstimateEstimateResponse
     {
@@ -1097,12 +1068,10 @@ final class EstimateActions implements EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateSubscriptionEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function updateSubscription(array $params, array $headers = []): UpdateSubscriptionEstimateResponse
     {
@@ -1186,12 +1155,10 @@ final class EstimateActions implements EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return GiftSubscriptionEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function giftSubscription(array $params, array $headers = []): GiftSubscriptionEstimateResponse
     {
@@ -1280,12 +1247,10 @@ final class EstimateActions implements EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateSubForCustomerEstimateEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createSubForCustomerEstimate(string $id, array $params, array $headers = []): CreateSubForCustomerEstimateEstimateResponse
     {
@@ -1398,12 +1363,10 @@ final class EstimateActions implements EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateSubscriptionEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createSubscription(array $params, array $headers = []): CreateSubscriptionEstimateResponse
     {
@@ -1497,12 +1460,10 @@ final class EstimateActions implements EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateInvoiceEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createInvoice(array $params = [], array $headers = []): CreateInvoiceEstimateResponse
     {
@@ -1548,12 +1509,10 @@ final class EstimateActions implements EstimateActionsInterface
     *   @param array<string, string> $headers
     *   @return CancelSubscriptionEstimateResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function cancelSubscription(string $id, array $params = [], array $headers = []): CancelSubscriptionEstimateResponse
     {

--- a/src/Actions/EventActions.php
+++ b/src/Actions/EventActions.php
@@ -11,7 +11,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -73,12 +72,10 @@ final class EventActions implements EventActionsInterface
     *   @param array<string, string> $headers
     *   @return ListEventResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListEventResponse
     {
@@ -106,12 +103,10 @@ final class EventActions implements EventActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveEventResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveEventResponse
     {

--- a/src/Actions/EventActions.php
+++ b/src/Actions/EventActions.php
@@ -10,6 +10,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class EventActions implements EventActionsInterface
 {
@@ -66,6 +72,13 @@ final class EventActions implements EventActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListEventResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListEventResponse
     {
@@ -92,6 +105,13 @@ final class EventActions implements EventActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveEventResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveEventResponse
     {

--- a/src/Actions/ExportActions.php
+++ b/src/Actions/ExportActions.php
@@ -25,6 +25,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class ExportActions implements ExportActionsInterface
 {
@@ -143,6 +149,13 @@ final class ExportActions implements ExportActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CustomersExportResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function customers(array $params = [], array $headers = []): CustomersExportResponse
     {
@@ -218,6 +231,13 @@ final class ExportActions implements ExportActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return AttachedItemsExportResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function attachedItems(array $params = [], array $headers = []): AttachedItemsExportResponse
     {
@@ -351,6 +371,13 @@ final class ExportActions implements ExportActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return TransactionsExportResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function transactions(array $params = [], array $headers = []): TransactionsExportResponse
     {
@@ -409,6 +436,13 @@ final class ExportActions implements ExportActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return DifferentialPricesExportResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function differentialPrices(array $params = [], array $headers = []): DifferentialPricesExportResponse
     {
@@ -464,6 +498,13 @@ final class ExportActions implements ExportActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ItemFamiliesExportResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function itemFamilies(array $params = [], array $headers = []): ItemFamiliesExportResponse
     {
@@ -614,6 +655,13 @@ final class ExportActions implements ExportActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return InvoicesExportResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function invoices(array $params = [], array $headers = []): InvoicesExportResponse
     {
@@ -641,6 +689,13 @@ final class ExportActions implements ExportActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveExportResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveExportResponse
     {
@@ -708,6 +763,13 @@ final class ExportActions implements ExportActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return PriceVariantsExportResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function priceVariants(array $params = [], array $headers = []): PriceVariantsExportResponse
     {
@@ -812,6 +874,13 @@ final class ExportActions implements ExportActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ItemsExportResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function items(array $params = [], array $headers = []): ItemsExportResponse
     {
@@ -1170,6 +1239,13 @@ final class ExportActions implements ExportActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return DeferredRevenueExportResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function deferredRevenue(array $params, array $headers = []): DeferredRevenueExportResponse
     {
@@ -1528,6 +1604,13 @@ final class ExportActions implements ExportActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return RevenueRecognitionExportResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function revenueRecognition(array $params, array $headers = []): RevenueRecognitionExportResponse
     {
@@ -1679,6 +1762,13 @@ final class ExportActions implements ExportActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreditNotesExportResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function creditNotes(array $params = [], array $headers = []): CreditNotesExportResponse
     {
@@ -1766,6 +1856,13 @@ final class ExportActions implements ExportActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CouponsExportResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function coupons(array $params = [], array $headers = []): CouponsExportResponse
     {
@@ -1916,6 +2013,13 @@ final class ExportActions implements ExportActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return OrdersExportResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function orders(array $params = [], array $headers = []): OrdersExportResponse
     {
@@ -2055,6 +2159,13 @@ final class ExportActions implements ExportActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ItemPricesExportResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function itemPrices(array $params = [], array $headers = []): ItemPricesExportResponse
     {
@@ -2200,6 +2311,13 @@ final class ExportActions implements ExportActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return SubscriptionsExportResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function subscriptions(array $params = [], array $headers = []): SubscriptionsExportResponse
     {
@@ -2299,6 +2417,13 @@ final class ExportActions implements ExportActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return AddonsExportResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function addons(array $params = [], array $headers = []): AddonsExportResponse
     {
@@ -2417,6 +2542,13 @@ final class ExportActions implements ExportActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return PlansExportResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function plans(array $params = [], array $headers = []): PlansExportResponse
     {

--- a/src/Actions/ExportActions.php
+++ b/src/Actions/ExportActions.php
@@ -26,7 +26,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -150,12 +149,10 @@ final class ExportActions implements ExportActionsInterface
     *   @param array<string, string> $headers
     *   @return CustomersExportResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function customers(array $params = [], array $headers = []): CustomersExportResponse
     {
@@ -232,12 +229,10 @@ final class ExportActions implements ExportActionsInterface
     *   @param array<string, string> $headers
     *   @return AttachedItemsExportResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function attachedItems(array $params = [], array $headers = []): AttachedItemsExportResponse
     {
@@ -372,12 +367,10 @@ final class ExportActions implements ExportActionsInterface
     *   @param array<string, string> $headers
     *   @return TransactionsExportResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function transactions(array $params = [], array $headers = []): TransactionsExportResponse
     {
@@ -437,12 +430,10 @@ final class ExportActions implements ExportActionsInterface
     *   @param array<string, string> $headers
     *   @return DifferentialPricesExportResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function differentialPrices(array $params = [], array $headers = []): DifferentialPricesExportResponse
     {
@@ -499,12 +490,10 @@ final class ExportActions implements ExportActionsInterface
     *   @param array<string, string> $headers
     *   @return ItemFamiliesExportResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function itemFamilies(array $params = [], array $headers = []): ItemFamiliesExportResponse
     {
@@ -656,12 +645,10 @@ final class ExportActions implements ExportActionsInterface
     *   @param array<string, string> $headers
     *   @return InvoicesExportResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function invoices(array $params = [], array $headers = []): InvoicesExportResponse
     {
@@ -690,12 +677,10 @@ final class ExportActions implements ExportActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveExportResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveExportResponse
     {
@@ -764,12 +749,10 @@ final class ExportActions implements ExportActionsInterface
     *   @param array<string, string> $headers
     *   @return PriceVariantsExportResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function priceVariants(array $params = [], array $headers = []): PriceVariantsExportResponse
     {
@@ -875,12 +858,10 @@ final class ExportActions implements ExportActionsInterface
     *   @param array<string, string> $headers
     *   @return ItemsExportResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function items(array $params = [], array $headers = []): ItemsExportResponse
     {
@@ -1240,12 +1221,10 @@ final class ExportActions implements ExportActionsInterface
     *   @param array<string, string> $headers
     *   @return DeferredRevenueExportResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function deferredRevenue(array $params, array $headers = []): DeferredRevenueExportResponse
     {
@@ -1605,12 +1584,10 @@ final class ExportActions implements ExportActionsInterface
     *   @param array<string, string> $headers
     *   @return RevenueRecognitionExportResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function revenueRecognition(array $params, array $headers = []): RevenueRecognitionExportResponse
     {
@@ -1763,12 +1740,10 @@ final class ExportActions implements ExportActionsInterface
     *   @param array<string, string> $headers
     *   @return CreditNotesExportResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function creditNotes(array $params = [], array $headers = []): CreditNotesExportResponse
     {
@@ -1857,12 +1832,10 @@ final class ExportActions implements ExportActionsInterface
     *   @param array<string, string> $headers
     *   @return CouponsExportResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function coupons(array $params = [], array $headers = []): CouponsExportResponse
     {
@@ -2014,12 +1987,10 @@ final class ExportActions implements ExportActionsInterface
     *   @param array<string, string> $headers
     *   @return OrdersExportResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function orders(array $params = [], array $headers = []): OrdersExportResponse
     {
@@ -2160,12 +2131,10 @@ final class ExportActions implements ExportActionsInterface
     *   @param array<string, string> $headers
     *   @return ItemPricesExportResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function itemPrices(array $params = [], array $headers = []): ItemPricesExportResponse
     {
@@ -2312,12 +2281,10 @@ final class ExportActions implements ExportActionsInterface
     *   @param array<string, string> $headers
     *   @return SubscriptionsExportResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function subscriptions(array $params = [], array $headers = []): SubscriptionsExportResponse
     {
@@ -2418,12 +2385,10 @@ final class ExportActions implements ExportActionsInterface
     *   @param array<string, string> $headers
     *   @return AddonsExportResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function addons(array $params = [], array $headers = []): AddonsExportResponse
     {
@@ -2543,12 +2508,10 @@ final class ExportActions implements ExportActionsInterface
     *   @param array<string, string> $headers
     *   @return PlansExportResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function plans(array $params = [], array $headers = []): PlansExportResponse
     {

--- a/src/Actions/FeatureActions.php
+++ b/src/Actions/FeatureActions.php
@@ -17,7 +17,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -68,12 +67,10 @@ final class FeatureActions implements FeatureActionsInterface
     *   @param array<string, string> $headers
     *   @return ListFeatureResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListFeatureResponse
     {
@@ -113,12 +110,10 @@ final class FeatureActions implements FeatureActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateFeatureResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateFeatureResponse
     {
@@ -147,12 +142,10 @@ final class FeatureActions implements FeatureActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteFeatureResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteFeatureResponse
     {
@@ -180,12 +173,10 @@ final class FeatureActions implements FeatureActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveFeatureResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveFeatureResponse
     {
@@ -222,12 +213,10 @@ final class FeatureActions implements FeatureActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateFeatureResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdateFeatureResponse
     {
@@ -256,12 +245,10 @@ final class FeatureActions implements FeatureActionsInterface
     *   @param array<string, string> $headers
     *   @return ArchiveFeatureResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function archive(string $id, array $headers = []): ArchiveFeatureResponse
     {
@@ -289,12 +276,10 @@ final class FeatureActions implements FeatureActionsInterface
     *   @param array<string, string> $headers
     *   @return ActivateFeatureResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function activate(string $id, array $headers = []): ActivateFeatureResponse
     {
@@ -322,12 +307,10 @@ final class FeatureActions implements FeatureActionsInterface
     *   @param array<string, string> $headers
     *   @return ReactivateFeatureResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function reactivate(string $id, array $headers = []): ReactivateFeatureResponse
     {

--- a/src/Actions/FeatureActions.php
+++ b/src/Actions/FeatureActions.php
@@ -16,6 +16,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class FeatureActions implements FeatureActionsInterface
 {
@@ -61,6 +67,13 @@ final class FeatureActions implements FeatureActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListFeatureResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListFeatureResponse
     {
@@ -99,6 +112,13 @@ final class FeatureActions implements FeatureActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateFeatureResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateFeatureResponse
     {
@@ -126,6 +146,13 @@ final class FeatureActions implements FeatureActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteFeatureResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteFeatureResponse
     {
@@ -152,6 +179,13 @@ final class FeatureActions implements FeatureActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveFeatureResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveFeatureResponse
     {
@@ -187,6 +221,13 @@ final class FeatureActions implements FeatureActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateFeatureResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdateFeatureResponse
     {
@@ -214,6 +255,13 @@ final class FeatureActions implements FeatureActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ArchiveFeatureResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function archive(string $id, array $headers = []): ArchiveFeatureResponse
     {
@@ -240,6 +288,13 @@ final class FeatureActions implements FeatureActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ActivateFeatureResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function activate(string $id, array $headers = []): ActivateFeatureResponse
     {
@@ -266,6 +321,13 @@ final class FeatureActions implements FeatureActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ReactivateFeatureResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function reactivate(string $id, array $headers = []): ReactivateFeatureResponse
     {

--- a/src/Actions/GiftActions.php
+++ b/src/Actions/GiftActions.php
@@ -15,6 +15,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class GiftActions implements GiftActionsInterface
 {
@@ -79,6 +85,13 @@ final class GiftActions implements GiftActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateForItemsGiftResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createForItems(array $params, array $headers = []): CreateForItemsGiftResponse
     {
@@ -107,6 +120,13 @@ final class GiftActions implements GiftActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CancelGiftResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function cancel(string $id, array $headers = []): CancelGiftResponse
     {
@@ -136,6 +156,13 @@ final class GiftActions implements GiftActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateGiftGiftResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function updateGift(string $id, array $params, array $headers = []): UpdateGiftGiftResponse
     {
@@ -191,6 +218,13 @@ final class GiftActions implements GiftActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListGiftResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListGiftResponse
     {
@@ -270,6 +304,13 @@ final class GiftActions implements GiftActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateGiftResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateGiftResponse
     {
@@ -298,6 +339,13 @@ final class GiftActions implements GiftActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveGiftResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveGiftResponse
     {
@@ -323,6 +371,13 @@ final class GiftActions implements GiftActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ClaimGiftResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function claim(string $id, array $headers = []): ClaimGiftResponse
     {

--- a/src/Actions/GiftActions.php
+++ b/src/Actions/GiftActions.php
@@ -16,7 +16,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -86,12 +85,10 @@ final class GiftActions implements GiftActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateForItemsGiftResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createForItems(array $params, array $headers = []): CreateForItemsGiftResponse
     {
@@ -121,12 +118,10 @@ final class GiftActions implements GiftActionsInterface
     *   @param array<string, string> $headers
     *   @return CancelGiftResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function cancel(string $id, array $headers = []): CancelGiftResponse
     {
@@ -157,12 +152,10 @@ final class GiftActions implements GiftActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateGiftGiftResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function updateGift(string $id, array $params, array $headers = []): UpdateGiftGiftResponse
     {
@@ -219,12 +212,10 @@ final class GiftActions implements GiftActionsInterface
     *   @param array<string, string> $headers
     *   @return ListGiftResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListGiftResponse
     {
@@ -305,12 +296,10 @@ final class GiftActions implements GiftActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateGiftResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateGiftResponse
     {
@@ -340,12 +329,10 @@ final class GiftActions implements GiftActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveGiftResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveGiftResponse
     {
@@ -372,12 +359,10 @@ final class GiftActions implements GiftActionsInterface
     *   @param array<string, string> $headers
     *   @return ClaimGiftResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function claim(string $id, array $headers = []): ClaimGiftResponse
     {

--- a/src/Actions/HostedPageActions.php
+++ b/src/Actions/HostedPageActions.php
@@ -31,7 +31,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -168,12 +167,10 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return CheckoutOneTimeForItemsHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function checkoutOneTimeForItems(array $params, array $headers = []): CheckoutOneTimeForItemsHostedPageResponse
     {
@@ -217,12 +214,10 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdatePaymentMethodHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function updatePaymentMethod(array $params, array $headers = []): UpdatePaymentMethodHostedPageResponse
     {
@@ -266,12 +261,10 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateCardHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function updateCard(array $params, array $headers = []): UpdateCardHostedPageResponse
     {
@@ -306,12 +299,10 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return ExtendSubscriptionHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function extendSubscription(array $params, array $headers = []): ExtendSubscriptionHostedPageResponse
     {
@@ -344,12 +335,10 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return EventsHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function events(array $params, array $headers = []): EventsHostedPageResponse
     {
@@ -391,12 +380,10 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return CheckoutGiftForItemsHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function checkoutGiftForItems(array $params = [], array $headers = []): CheckoutGiftForItemsHostedPageResponse
     {
@@ -453,12 +440,10 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return ListHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListHostedPageResponse
     {
@@ -493,12 +478,10 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return ViewVoucherHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function viewVoucher(array $params, array $headers = []): ViewVoucherHostedPageResponse
     {
@@ -537,12 +520,10 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return CollectNowHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function collectNow(array $params, array $headers = []): CollectNowHostedPageResponse
     {
@@ -577,12 +558,10 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return AcceptQuoteHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function acceptQuote(array $params, array $headers = []): AcceptQuoteHostedPageResponse
     {
@@ -733,12 +712,10 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return CheckoutNewForItemsHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function checkoutNewForItems(array $params, array $headers = []): CheckoutNewForItemsHostedPageResponse
     {
@@ -775,12 +752,10 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return ClaimGiftHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function claimGift(array $params, array $headers = []): ClaimGiftHostedPageResponse
     {
@@ -899,12 +874,10 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return CheckoutExistingForItemsHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function checkoutExistingForItems(array $params, array $headers = []): CheckoutExistingForItemsHostedPageResponse
     {
@@ -940,12 +913,10 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return PreCancelHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function preCancel(array $params, array $headers = []): PreCancelHostedPageResponse
     {
@@ -974,12 +945,10 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return AcknowledgeHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function acknowledge(string $id, array $headers = []): AcknowledgeHostedPageResponse
     {
@@ -1009,12 +978,10 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveAgreementPdfHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieveAgreementPdf(array $params, array $headers = []): RetrieveAgreementPdfHostedPageResponse
     {
@@ -1043,12 +1010,10 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveHostedPageResponse
     {
@@ -1084,12 +1049,10 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return ManagePaymentSourcesHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function managePaymentSources(array $params, array $headers = []): ManagePaymentSourcesHostedPageResponse
     {
@@ -1204,12 +1167,10 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return CheckoutOneTimeHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function checkoutOneTime(array $params = [], array $headers = []): CheckoutOneTimeHostedPageResponse
     {
@@ -1339,12 +1300,10 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return CheckoutNewHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function checkoutNew(array $params, array $headers = []): CheckoutNewHostedPageResponse
     {
@@ -1390,12 +1349,10 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return CheckoutGiftHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function checkoutGift(array $params, array $headers = []): CheckoutGiftHostedPageResponse
     {
@@ -1489,12 +1446,10 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   @param array<string, string> $headers
     *   @return CheckoutExistingHostedPageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function checkoutExisting(array $params, array $headers = []): CheckoutExistingHostedPageResponse
     {

--- a/src/Actions/HostedPageActions.php
+++ b/src/Actions/HostedPageActions.php
@@ -30,6 +30,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class HostedPageActions implements HostedPageActionsInterface
 {
@@ -161,6 +167,13 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CheckoutOneTimeForItemsHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function checkoutOneTimeForItems(array $params, array $headers = []): CheckoutOneTimeForItemsHostedPageResponse
     {
@@ -203,6 +216,13 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return UpdatePaymentMethodHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function updatePaymentMethod(array $params, array $headers = []): UpdatePaymentMethodHostedPageResponse
     {
@@ -245,6 +265,13 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return UpdateCardHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function updateCard(array $params, array $headers = []): UpdateCardHostedPageResponse
     {
@@ -278,6 +305,13 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ExtendSubscriptionHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function extendSubscription(array $params, array $headers = []): ExtendSubscriptionHostedPageResponse
     {
@@ -309,6 +343,13 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return EventsHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function events(array $params, array $headers = []): EventsHostedPageResponse
     {
@@ -349,6 +390,13 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CheckoutGiftForItemsHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function checkoutGiftForItems(array $params = [], array $headers = []): CheckoutGiftForItemsHostedPageResponse
     {
@@ -404,6 +452,13 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListHostedPageResponse
     {
@@ -437,6 +492,13 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ViewVoucherHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function viewVoucher(array $params, array $headers = []): ViewVoucherHostedPageResponse
     {
@@ -474,6 +536,13 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CollectNowHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function collectNow(array $params, array $headers = []): CollectNowHostedPageResponse
     {
@@ -507,6 +576,13 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return AcceptQuoteHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function acceptQuote(array $params, array $headers = []): AcceptQuoteHostedPageResponse
     {
@@ -656,6 +732,13 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CheckoutNewForItemsHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function checkoutNewForItems(array $params, array $headers = []): CheckoutNewForItemsHostedPageResponse
     {
@@ -691,6 +774,13 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ClaimGiftHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function claimGift(array $params, array $headers = []): ClaimGiftHostedPageResponse
     {
@@ -808,6 +898,13 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CheckoutExistingForItemsHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function checkoutExistingForItems(array $params, array $headers = []): CheckoutExistingForItemsHostedPageResponse
     {
@@ -842,6 +939,13 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return PreCancelHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function preCancel(array $params, array $headers = []): PreCancelHostedPageResponse
     {
@@ -869,6 +973,13 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return AcknowledgeHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function acknowledge(string $id, array $headers = []): AcknowledgeHostedPageResponse
     {
@@ -897,6 +1008,13 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return RetrieveAgreementPdfHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieveAgreementPdf(array $params, array $headers = []): RetrieveAgreementPdfHostedPageResponse
     {
@@ -924,6 +1042,13 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveHostedPageResponse
     {
@@ -958,6 +1083,13 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ManagePaymentSourcesHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function managePaymentSources(array $params, array $headers = []): ManagePaymentSourcesHostedPageResponse
     {
@@ -1071,6 +1203,13 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CheckoutOneTimeHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function checkoutOneTime(array $params = [], array $headers = []): CheckoutOneTimeHostedPageResponse
     {
@@ -1199,6 +1338,13 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CheckoutNewHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function checkoutNew(array $params, array $headers = []): CheckoutNewHostedPageResponse
     {
@@ -1243,6 +1389,13 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CheckoutGiftHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function checkoutGift(array $params, array $headers = []): CheckoutGiftHostedPageResponse
     {
@@ -1335,6 +1488,13 @@ final class HostedPageActions implements HostedPageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CheckoutExistingHostedPageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function checkoutExisting(array $params, array $headers = []): CheckoutExistingHostedPageResponse
     {

--- a/src/Actions/InAppSubscriptionActions.php
+++ b/src/Actions/InAppSubscriptionActions.php
@@ -12,7 +12,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -36,12 +35,10 @@ final class InAppSubscriptionActions implements InAppSubscriptionActionsInterfac
     *   @param array<string, string> $headers
     *   @return RetrieveStoreSubsInAppSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieveStoreSubs(string $id, array $params, array $headers = []): RetrieveStoreSubsInAppSubscriptionResponse
     {
@@ -79,12 +76,10 @@ final class InAppSubscriptionActions implements InAppSubscriptionActionsInterfac
     *   @param array<string, string> $headers
     *   @return ImportReceiptInAppSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function importReceipt(string $id, array $params, array $headers = []): ImportReceiptInAppSubscriptionResponse
     {
@@ -128,12 +123,10 @@ final class InAppSubscriptionActions implements InAppSubscriptionActionsInterfac
     *   @param array<string, string> $headers
     *   @return ImportSubscriptionInAppSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function importSubscription(string $id, array $params, array $headers = []): ImportSubscriptionInAppSubscriptionResponse
     {
@@ -179,12 +172,10 @@ final class InAppSubscriptionActions implements InAppSubscriptionActionsInterfac
     *   @param array<string, string> $headers
     *   @return ProcessReceiptInAppSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function processReceipt(string $id, array $params, array $headers = []): ProcessReceiptInAppSubscriptionResponse
     {

--- a/src/Actions/InAppSubscriptionActions.php
+++ b/src/Actions/InAppSubscriptionActions.php
@@ -11,6 +11,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class InAppSubscriptionActions implements InAppSubscriptionActionsInterface
 {
@@ -29,6 +35,13 @@ final class InAppSubscriptionActions implements InAppSubscriptionActionsInterfac
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveStoreSubsInAppSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieveStoreSubs(string $id, array $params, array $headers = []): RetrieveStoreSubsInAppSubscriptionResponse
     {
@@ -65,6 +78,13 @@ final class InAppSubscriptionActions implements InAppSubscriptionActionsInterfac
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ImportReceiptInAppSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function importReceipt(string $id, array $params, array $headers = []): ImportReceiptInAppSubscriptionResponse
     {
@@ -107,6 +127,13 @@ final class InAppSubscriptionActions implements InAppSubscriptionActionsInterfac
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ImportSubscriptionInAppSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function importSubscription(string $id, array $params, array $headers = []): ImportSubscriptionInAppSubscriptionResponse
     {
@@ -151,6 +178,13 @@ final class InAppSubscriptionActions implements InAppSubscriptionActionsInterfac
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ProcessReceiptInAppSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function processReceipt(string $id, array $params, array $headers = []): ProcessReceiptInAppSubscriptionResponse
     {

--- a/src/Actions/InvoiceActions.php
+++ b/src/Actions/InvoiceActions.php
@@ -49,7 +49,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -75,12 +74,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteLineItemsInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function deleteLineItems(string $id, array $params = [], array $headers = []): DeleteLineItemsInvoiceResponse
     {
@@ -113,12 +110,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return RemoveCreditNoteInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function removeCreditNote(string $id, array $params, array $headers = []): RemoveCreditNoteInvoiceResponse
     {
@@ -151,12 +146,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return RemovePaymentInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function removePayment(string $id, array $params, array $headers = []): RemovePaymentInvoiceResponse
     {
@@ -187,12 +180,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return StopDunningInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function stopDunning(string $id, array $params = [], array $headers = []): StopDunningInvoiceResponse
     {
@@ -227,12 +218,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return ApplyPaymentsInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function applyPayments(string $id, array $params = [], array $headers = []): ApplyPaymentsInvoiceResponse
     {
@@ -264,12 +253,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return ApplyPaymentScheduleSchemeInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function applyPaymentScheduleScheme(string $id, array $params, array $headers = []): ApplyPaymentScheduleSchemeInvoiceResponse
     {
@@ -301,12 +288,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return VoidInvoiceInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function voidInvoice(string $id, array $params = [], array $headers = []): VoidInvoiceInvoiceResponse
     {
@@ -350,12 +335,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return AddChargeInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function addCharge(string $id, array $params, array $headers = []): AddChargeInvoiceResponse
     {
@@ -384,12 +367,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return SendEinvoiceInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function sendEinvoice(string $id, array $headers = []): SendEinvoiceInvoiceResponse
     {
@@ -417,12 +398,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return PaymentSchedulesInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function paymentSchedules(string $id, array $headers = []): PaymentSchedulesInvoiceResponse
     {
@@ -451,12 +430,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return WriteOffInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function writeOff(string $id, array $params = [], array $headers = []): WriteOffInvoiceResponse
     {
@@ -507,12 +484,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return AddChargeItemInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function addChargeItem(string $id, array $params, array $headers = []): AddChargeItemInvoiceResponse
     {
@@ -544,12 +519,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return PauseDunningInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function pauseDunning(string $id, array $params, array $headers = []): PauseDunningInvoiceResponse
     {
@@ -728,12 +701,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return ListInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListInvoiceResponse
     {
@@ -888,12 +859,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params = [], array $headers = []): CreateInvoiceResponse
     {
@@ -933,12 +902,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return CloseInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function close(string $id, array $params = [], array $headers = []): CloseInvoiceResponse
     {
@@ -972,12 +939,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return ApplyCreditsInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function applyCredits(string $id, array $params = [], array $headers = []): ApplyCreditsInvoiceResponse
     {
@@ -1015,12 +980,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $params = [], array $headers = []): RetrieveInvoiceResponse
     {
@@ -1075,12 +1038,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateForChargeItemInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createForChargeItem(array $params, array $headers = []): CreateForChargeItemInvoiceResponse
     {
@@ -1254,12 +1215,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateForChargeItemsAndChargesInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createForChargeItemsAndCharges(array $params, array $headers = []): CreateForChargeItemsAndChargesInvoiceResponse
     {
@@ -1330,12 +1289,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateDetailsInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function updateDetails(string $id, array $params = [], array $headers = []): UpdateDetailsInvoiceResponse
     {
@@ -1367,12 +1324,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return InvoicesForCustomerInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function invoicesForCustomer(string $id, array $params = [], array $headers = []): InvoicesForCustomerInvoiceResponse
     {
@@ -1413,12 +1368,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return RecordPaymentInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function recordPayment(string $id, array $params, array $headers = []): RecordPaymentInvoiceResponse
     {
@@ -1449,12 +1402,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $params = [], array $headers = []): DeleteInvoiceResponse
     {
@@ -1641,12 +1592,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return ImportInvoiceInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function importInvoice(array $params, array $headers = []): ImportInvoiceInvoiceResponse
     {
@@ -1677,12 +1626,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return ResumeDunningInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function resumeDunning(string $id, array $params = [], array $headers = []): ResumeDunningInvoiceResponse
     {
@@ -1718,12 +1665,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return RecordTaxWithheldInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function recordTaxWithheld(string $id, array $params, array $headers = []): RecordTaxWithheldInvoiceResponse
     {
@@ -1752,12 +1697,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return ResendEinvoiceInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function resendEinvoice(string $id, array $headers = []): ResendEinvoiceInvoiceResponse
     {
@@ -1789,12 +1732,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return RemoveTaxWithheldInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function removeTaxWithheld(string $id, array $params, array $headers = []): RemoveTaxWithheldInvoiceResponse
     {
@@ -1836,12 +1777,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return ListPaymentReferenceNumbersInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function listPaymentReferenceNumbers(array $params = [], array $headers = []): ListPaymentReferenceNumbersInvoiceResponse
     {
@@ -1875,12 +1814,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return CollectPaymentInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function collectPayment(string $id, array $params = [], array $headers = []): CollectPaymentInvoiceResponse
     {
@@ -1909,12 +1846,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return SyncUsagesInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function syncUsages(string $id, array $headers = []): SyncUsagesInvoiceResponse
     {
@@ -1950,12 +1885,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return RefundInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function refund(string $id, array $params = [], array $headers = []): RefundInvoiceResponse
     {
@@ -1998,12 +1931,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return RecordRefundInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function recordRefund(string $id, array $params, array $headers = []): RecordRefundInvoiceResponse
     {
@@ -2034,12 +1965,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return PdfInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function pdf(string $id, array $params = [], array $headers = []): PdfInvoiceResponse
     {
@@ -2071,12 +2000,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return InvoicesForSubscriptionInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function invoicesForSubscription(string $id, array $params = [], array $headers = []): InvoicesForSubscriptionInvoiceResponse
     {
@@ -2104,12 +2031,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return DownloadEinvoiceInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function downloadEinvoice(string $id, array $headers = []): DownloadEinvoiceInvoiceResponse
     {
@@ -2152,12 +2077,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return ChargeAddonInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function chargeAddon(array $params, array $headers = []): ChargeAddonInvoiceResponse
     {
@@ -2198,12 +2121,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return AddAddonChargeInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function addAddonCharge(string $id, array $params, array $headers = []): AddAddonChargeInvoiceResponse
     {
@@ -2255,12 +2176,10 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param array<string, string> $headers
     *   @return ChargeInvoiceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function charge(array $params, array $headers = []): ChargeInvoiceResponse
     {

--- a/src/Actions/InvoiceActions.php
+++ b/src/Actions/InvoiceActions.php
@@ -48,6 +48,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class InvoiceActions implements InvoiceActionsInterface
 {
@@ -68,6 +74,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteLineItemsInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function deleteLineItems(string $id, array $params = [], array $headers = []): DeleteLineItemsInvoiceResponse
     {
@@ -99,6 +112,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RemoveCreditNoteInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function removeCreditNote(string $id, array $params, array $headers = []): RemoveCreditNoteInvoiceResponse
     {
@@ -130,6 +150,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RemovePaymentInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function removePayment(string $id, array $params, array $headers = []): RemovePaymentInvoiceResponse
     {
@@ -159,6 +186,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return StopDunningInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function stopDunning(string $id, array $params = [], array $headers = []): StopDunningInvoiceResponse
     {
@@ -192,6 +226,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ApplyPaymentsInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function applyPayments(string $id, array $params = [], array $headers = []): ApplyPaymentsInvoiceResponse
     {
@@ -222,6 +263,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ApplyPaymentScheduleSchemeInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function applyPaymentScheduleScheme(string $id, array $params, array $headers = []): ApplyPaymentScheduleSchemeInvoiceResponse
     {
@@ -252,6 +300,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return VoidInvoiceInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function voidInvoice(string $id, array $params = [], array $headers = []): VoidInvoiceInvoiceResponse
     {
@@ -294,6 +349,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return AddChargeInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function addCharge(string $id, array $params, array $headers = []): AddChargeInvoiceResponse
     {
@@ -321,6 +383,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return SendEinvoiceInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function sendEinvoice(string $id, array $headers = []): SendEinvoiceInvoiceResponse
     {
@@ -347,6 +416,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return PaymentSchedulesInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function paymentSchedules(string $id, array $headers = []): PaymentSchedulesInvoiceResponse
     {
@@ -374,6 +450,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return WriteOffInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function writeOff(string $id, array $params = [], array $headers = []): WriteOffInvoiceResponse
     {
@@ -423,6 +506,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return AddChargeItemInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function addChargeItem(string $id, array $params, array $headers = []): AddChargeItemInvoiceResponse
     {
@@ -453,6 +543,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return PauseDunningInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function pauseDunning(string $id, array $params, array $headers = []): PauseDunningInvoiceResponse
     {
@@ -630,6 +727,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListInvoiceResponse
     {
@@ -783,6 +887,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params = [], array $headers = []): CreateInvoiceResponse
     {
@@ -821,6 +932,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CloseInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function close(string $id, array $params = [], array $headers = []): CloseInvoiceResponse
     {
@@ -853,6 +971,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ApplyCreditsInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function applyCredits(string $id, array $params = [], array $headers = []): ApplyCreditsInvoiceResponse
     {
@@ -889,6 +1014,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $params = [], array $headers = []): RetrieveInvoiceResponse
     {
@@ -942,6 +1074,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateForChargeItemInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createForChargeItem(array $params, array $headers = []): CreateForChargeItemInvoiceResponse
     {
@@ -1114,6 +1253,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateForChargeItemsAndChargesInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createForChargeItemsAndCharges(array $params, array $headers = []): CreateForChargeItemsAndChargesInvoiceResponse
     {
@@ -1183,6 +1329,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateDetailsInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function updateDetails(string $id, array $params = [], array $headers = []): UpdateDetailsInvoiceResponse
     {
@@ -1213,6 +1366,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return InvoicesForCustomerInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function invoicesForCustomer(string $id, array $params = [], array $headers = []): InvoicesForCustomerInvoiceResponse
     {
@@ -1252,6 +1412,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RecordPaymentInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function recordPayment(string $id, array $params, array $headers = []): RecordPaymentInvoiceResponse
     {
@@ -1281,6 +1448,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $params = [], array $headers = []): DeleteInvoiceResponse
     {
@@ -1466,6 +1640,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ImportInvoiceInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function importInvoice(array $params, array $headers = []): ImportInvoiceInvoiceResponse
     {
@@ -1495,6 +1676,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ResumeDunningInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function resumeDunning(string $id, array $params = [], array $headers = []): ResumeDunningInvoiceResponse
     {
@@ -1529,6 +1717,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RecordTaxWithheldInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function recordTaxWithheld(string $id, array $params, array $headers = []): RecordTaxWithheldInvoiceResponse
     {
@@ -1556,6 +1751,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ResendEinvoiceInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function resendEinvoice(string $id, array $headers = []): ResendEinvoiceInvoiceResponse
     {
@@ -1586,6 +1788,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RemoveTaxWithheldInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function removeTaxWithheld(string $id, array $params, array $headers = []): RemoveTaxWithheldInvoiceResponse
     {
@@ -1614,18 +1823,25 @@ final class InvoiceActions implements InvoiceActionsInterface
     *     offset?: string,
     *     payment_reference_number?: array{
     *     number?: array{
-    *         is?: string,
-    *             in?: string,
+    *         in?: string,
+    *             is?: string,
     *             },
     *     },
     * id?: array{
-    *     is?: mixed,
     *     in?: mixed,
+    *     is?: mixed,
     *     },
     * } $params Description of the parameters
     *   
     *   @param array<string, string> $headers
     *   @return ListPaymentReferenceNumbersInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function listPaymentReferenceNumbers(array $params = [], array $headers = []): ListPaymentReferenceNumbersInvoiceResponse
     {
@@ -1658,6 +1874,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CollectPaymentInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function collectPayment(string $id, array $params = [], array $headers = []): CollectPaymentInvoiceResponse
     {
@@ -1685,6 +1908,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return SyncUsagesInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function syncUsages(string $id, array $headers = []): SyncUsagesInvoiceResponse
     {
@@ -1719,6 +1949,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RefundInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function refund(string $id, array $params = [], array $headers = []): RefundInvoiceResponse
     {
@@ -1760,6 +1997,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RecordRefundInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function recordRefund(string $id, array $params, array $headers = []): RecordRefundInvoiceResponse
     {
@@ -1789,6 +2033,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return PdfInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function pdf(string $id, array $params = [], array $headers = []): PdfInvoiceResponse
     {
@@ -1819,6 +2070,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return InvoicesForSubscriptionInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function invoicesForSubscription(string $id, array $params = [], array $headers = []): InvoicesForSubscriptionInvoiceResponse
     {
@@ -1845,6 +2103,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DownloadEinvoiceInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function downloadEinvoice(string $id, array $headers = []): DownloadEinvoiceInvoiceResponse
     {
@@ -1886,6 +2151,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ChargeAddonInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function chargeAddon(array $params, array $headers = []): ChargeAddonInvoiceResponse
     {
@@ -1925,6 +2197,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return AddAddonChargeInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function addAddonCharge(string $id, array $params, array $headers = []): AddAddonChargeInvoiceResponse
     {
@@ -1975,6 +2254,13 @@ final class InvoiceActions implements InvoiceActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ChargeInvoiceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function charge(array $params, array $headers = []): ChargeInvoiceResponse
     {

--- a/src/Actions/ItemActions.php
+++ b/src/Actions/ItemActions.php
@@ -14,7 +14,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -125,12 +124,10 @@ final class ItemActions implements ItemActionsInterface
     *   @param array<string, string> $headers
     *   @return ListItemResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListItemResponse
     {
@@ -189,12 +186,10 @@ final class ItemActions implements ItemActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateItemResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateItemResponse
     {
@@ -224,12 +219,10 @@ final class ItemActions implements ItemActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteItemResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteItemResponse
     {
@@ -257,12 +250,10 @@ final class ItemActions implements ItemActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveItemResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveItemResponse
     {
@@ -326,12 +317,10 @@ final class ItemActions implements ItemActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateItemResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdateItemResponse
     {

--- a/src/Actions/ItemActions.php
+++ b/src/Actions/ItemActions.php
@@ -13,6 +13,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class ItemActions implements ItemActionsInterface
 {
@@ -118,6 +124,13 @@ final class ItemActions implements ItemActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListItemResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListItemResponse
     {
@@ -175,6 +188,13 @@ final class ItemActions implements ItemActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateItemResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateItemResponse
     {
@@ -203,6 +223,13 @@ final class ItemActions implements ItemActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteItemResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteItemResponse
     {
@@ -229,6 +256,13 @@ final class ItemActions implements ItemActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveItemResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveItemResponse
     {
@@ -291,6 +325,13 @@ final class ItemActions implements ItemActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateItemResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdateItemResponse
     {

--- a/src/Actions/ItemEntitlementActions.php
+++ b/src/Actions/ItemEntitlementActions.php
@@ -12,6 +12,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class ItemEntitlementActions implements ItemEntitlementActionsInterface
 {
@@ -32,6 +38,13 @@ final class ItemEntitlementActions implements ItemEntitlementActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ItemEntitlementsForFeatureItemEntitlementResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function itemEntitlementsForFeature(string $id, array $params = [], array $headers = []): ItemEntitlementsForFeatureItemEntitlementResponse
     {
@@ -65,6 +78,13 @@ final class ItemEntitlementActions implements ItemEntitlementActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return AddItemEntitlementsItemEntitlementResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function addItemEntitlements(string $id, array $params, array $headers = []): AddItemEntitlementsItemEntitlementResponse
     {
@@ -97,6 +117,13 @@ final class ItemEntitlementActions implements ItemEntitlementActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ItemEntitlementsForItemItemEntitlementResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function itemEntitlementsForItem(string $id, array $params = [], array $headers = []): ItemEntitlementsForItemItemEntitlementResponse
     {
@@ -129,6 +156,13 @@ final class ItemEntitlementActions implements ItemEntitlementActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpsertOrRemoveItemEntitlementsForItemItemEntitlementResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function upsertOrRemoveItemEntitlementsForItem(string $id, array $params, array $headers = []): UpsertOrRemoveItemEntitlementsForItemItemEntitlementResponse
     {

--- a/src/Actions/ItemEntitlementActions.php
+++ b/src/Actions/ItemEntitlementActions.php
@@ -13,7 +13,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -39,12 +38,10 @@ final class ItemEntitlementActions implements ItemEntitlementActionsInterface
     *   @param array<string, string> $headers
     *   @return ItemEntitlementsForFeatureItemEntitlementResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function itemEntitlementsForFeature(string $id, array $params = [], array $headers = []): ItemEntitlementsForFeatureItemEntitlementResponse
     {
@@ -79,12 +76,10 @@ final class ItemEntitlementActions implements ItemEntitlementActionsInterface
     *   @param array<string, string> $headers
     *   @return AddItemEntitlementsItemEntitlementResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function addItemEntitlements(string $id, array $params, array $headers = []): AddItemEntitlementsItemEntitlementResponse
     {
@@ -118,12 +113,10 @@ final class ItemEntitlementActions implements ItemEntitlementActionsInterface
     *   @param array<string, string> $headers
     *   @return ItemEntitlementsForItemItemEntitlementResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function itemEntitlementsForItem(string $id, array $params = [], array $headers = []): ItemEntitlementsForItemItemEntitlementResponse
     {
@@ -157,12 +150,10 @@ final class ItemEntitlementActions implements ItemEntitlementActionsInterface
     *   @param array<string, string> $headers
     *   @return UpsertOrRemoveItemEntitlementsForItemItemEntitlementResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function upsertOrRemoveItemEntitlementsForItem(string $id, array $params, array $headers = []): UpsertOrRemoveItemEntitlementsForItemItemEntitlementResponse
     {

--- a/src/Actions/ItemFamilyActions.php
+++ b/src/Actions/ItemFamilyActions.php
@@ -13,6 +13,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class ItemFamilyActions implements ItemFamilyActionsInterface
 {
@@ -29,6 +35,13 @@ final class ItemFamilyActions implements ItemFamilyActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteItemFamilyResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteItemFamilyResponse
     {
@@ -83,6 +96,13 @@ final class ItemFamilyActions implements ItemFamilyActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListItemFamilyResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListItemFamilyResponse
     {
@@ -114,6 +134,13 @@ final class ItemFamilyActions implements ItemFamilyActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateItemFamilyResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateItemFamilyResponse
     {
@@ -141,6 +168,13 @@ final class ItemFamilyActions implements ItemFamilyActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveItemFamilyResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveItemFamilyResponse
     {
@@ -169,6 +203,13 @@ final class ItemFamilyActions implements ItemFamilyActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateItemFamilyResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdateItemFamilyResponse
     {

--- a/src/Actions/ItemFamilyActions.php
+++ b/src/Actions/ItemFamilyActions.php
@@ -14,7 +14,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -36,12 +35,10 @@ final class ItemFamilyActions implements ItemFamilyActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteItemFamilyResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteItemFamilyResponse
     {
@@ -97,12 +94,10 @@ final class ItemFamilyActions implements ItemFamilyActionsInterface
     *   @param array<string, string> $headers
     *   @return ListItemFamilyResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListItemFamilyResponse
     {
@@ -135,12 +130,10 @@ final class ItemFamilyActions implements ItemFamilyActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateItemFamilyResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateItemFamilyResponse
     {
@@ -169,12 +162,10 @@ final class ItemFamilyActions implements ItemFamilyActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveItemFamilyResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveItemFamilyResponse
     {
@@ -204,12 +195,10 @@ final class ItemFamilyActions implements ItemFamilyActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateItemFamilyResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdateItemFamilyResponse
     {

--- a/src/Actions/ItemPriceActions.php
+++ b/src/Actions/ItemPriceActions.php
@@ -15,6 +15,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class ItemPriceActions implements ItemPriceActionsInterface
 {
@@ -38,6 +44,13 @@ final class ItemPriceActions implements ItemPriceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return FindApplicableItemsItemPriceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function findApplicableItems(string $id, array $params = [], array $headers = []): FindApplicableItemsItemPriceResponse
     {
@@ -64,6 +77,13 @@ final class ItemPriceActions implements ItemPriceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveItemPriceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveItemPriceResponse
     {
@@ -148,6 +168,13 @@ final class ItemPriceActions implements ItemPriceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateItemPriceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params, array $headers = []): UpdateItemPriceResponse
     {
@@ -176,6 +203,13 @@ final class ItemPriceActions implements ItemPriceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteItemPriceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteItemPriceResponse
     {
@@ -210,6 +244,13 @@ final class ItemPriceActions implements ItemPriceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return FindApplicableItemPricesItemPriceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function findApplicableItemPrices(string $id, array $params = [], array $headers = []): FindApplicableItemPricesItemPriceResponse
     {
@@ -352,6 +393,13 @@ final class ItemPriceActions implements ItemPriceActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListItemPriceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListItemPriceResponse
     {
@@ -439,6 +487,13 @@ final class ItemPriceActions implements ItemPriceActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateItemPriceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateItemPriceResponse
     {

--- a/src/Actions/ItemPriceActions.php
+++ b/src/Actions/ItemPriceActions.php
@@ -16,7 +16,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -45,12 +44,10 @@ final class ItemPriceActions implements ItemPriceActionsInterface
     *   @param array<string, string> $headers
     *   @return FindApplicableItemsItemPriceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function findApplicableItems(string $id, array $params = [], array $headers = []): FindApplicableItemsItemPriceResponse
     {
@@ -78,12 +75,10 @@ final class ItemPriceActions implements ItemPriceActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveItemPriceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveItemPriceResponse
     {
@@ -169,12 +164,10 @@ final class ItemPriceActions implements ItemPriceActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateItemPriceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params, array $headers = []): UpdateItemPriceResponse
     {
@@ -204,12 +197,10 @@ final class ItemPriceActions implements ItemPriceActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteItemPriceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteItemPriceResponse
     {
@@ -245,12 +236,10 @@ final class ItemPriceActions implements ItemPriceActionsInterface
     *   @param array<string, string> $headers
     *   @return FindApplicableItemPricesItemPriceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function findApplicableItemPrices(string $id, array $params = [], array $headers = []): FindApplicableItemPricesItemPriceResponse
     {
@@ -394,12 +383,10 @@ final class ItemPriceActions implements ItemPriceActionsInterface
     *   @param array<string, string> $headers
     *   @return ListItemPriceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListItemPriceResponse
     {
@@ -488,12 +475,10 @@ final class ItemPriceActions implements ItemPriceActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateItemPriceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateItemPriceResponse
     {

--- a/src/Actions/NonSubscriptionActions.php
+++ b/src/Actions/NonSubscriptionActions.php
@@ -9,7 +9,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -47,12 +46,10 @@ final class NonSubscriptionActions implements NonSubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return ProcessReceiptNonSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function processReceipt(string $id, array $params, array $headers = []): ProcessReceiptNonSubscriptionResponse
     {

--- a/src/Actions/NonSubscriptionActions.php
+++ b/src/Actions/NonSubscriptionActions.php
@@ -8,6 +8,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class NonSubscriptionActions implements NonSubscriptionActionsInterface
 {
@@ -40,6 +46,13 @@ final class NonSubscriptionActions implements NonSubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ProcessReceiptNonSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function processReceipt(string $id, array $params, array $headers = []): ProcessReceiptNonSubscriptionResponse
     {

--- a/src/Actions/OmnichannelOneTimeOrderActions.php
+++ b/src/Actions/OmnichannelOneTimeOrderActions.php
@@ -10,6 +10,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class OmnichannelOneTimeOrderActions implements OmnichannelOneTimeOrderActionsInterface
 {
@@ -40,6 +46,13 @@ final class OmnichannelOneTimeOrderActions implements OmnichannelOneTimeOrderAct
     *   
     *   @param array<string, string> $headers
     *   @return ListOmnichannelOneTimeOrderResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListOmnichannelOneTimeOrderResponse
     {
@@ -66,6 +79,13 @@ final class OmnichannelOneTimeOrderActions implements OmnichannelOneTimeOrderAct
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveOmnichannelOneTimeOrderResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveOmnichannelOneTimeOrderResponse
     {

--- a/src/Actions/OmnichannelOneTimeOrderActions.php
+++ b/src/Actions/OmnichannelOneTimeOrderActions.php
@@ -11,7 +11,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -47,12 +46,10 @@ final class OmnichannelOneTimeOrderActions implements OmnichannelOneTimeOrderAct
     *   @param array<string, string> $headers
     *   @return ListOmnichannelOneTimeOrderResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListOmnichannelOneTimeOrderResponse
     {
@@ -80,12 +77,10 @@ final class OmnichannelOneTimeOrderActions implements OmnichannelOneTimeOrderAct
     *   @param array<string, string> $headers
     *   @return RetrieveOmnichannelOneTimeOrderResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveOmnichannelOneTimeOrderResponse
     {

--- a/src/Actions/OmnichannelSubscriptionActions.php
+++ b/src/Actions/OmnichannelSubscriptionActions.php
@@ -12,7 +12,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -34,12 +33,10 @@ final class OmnichannelSubscriptionActions implements OmnichannelSubscriptionAct
     *   @param array<string, string> $headers
     *   @return RetrieveOmnichannelSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveOmnichannelSubscriptionResponse
     {
@@ -69,12 +66,10 @@ final class OmnichannelSubscriptionActions implements OmnichannelSubscriptionAct
     *   @param array<string, string> $headers
     *   @return OmnichannelTransactionsForOmnichannelSubscriptionOmnichannelSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function omnichannelTransactionsForOmnichannelSubscription(string $id, array $params = [], array $headers = []): OmnichannelTransactionsForOmnichannelSubscriptionOmnichannelSubscriptionResponse
     {
@@ -116,12 +111,10 @@ final class OmnichannelSubscriptionActions implements OmnichannelSubscriptionAct
     *   @param array<string, string> $headers
     *   @return ListOmnichannelSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListOmnichannelSubscriptionResponse
     {

--- a/src/Actions/OmnichannelSubscriptionActions.php
+++ b/src/Actions/OmnichannelSubscriptionActions.php
@@ -11,6 +11,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class OmnichannelSubscriptionActions implements OmnichannelSubscriptionActionsInterface
 {
@@ -27,6 +33,13 @@ final class OmnichannelSubscriptionActions implements OmnichannelSubscriptionAct
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveOmnichannelSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveOmnichannelSubscriptionResponse
     {
@@ -55,6 +68,13 @@ final class OmnichannelSubscriptionActions implements OmnichannelSubscriptionAct
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return OmnichannelTransactionsForOmnichannelSubscriptionOmnichannelSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function omnichannelTransactionsForOmnichannelSubscription(string $id, array $params = [], array $headers = []): OmnichannelTransactionsForOmnichannelSubscriptionOmnichannelSubscriptionResponse
     {
@@ -95,6 +115,13 @@ final class OmnichannelSubscriptionActions implements OmnichannelSubscriptionAct
     *   
     *   @param array<string, string> $headers
     *   @return ListOmnichannelSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListOmnichannelSubscriptionResponse
     {

--- a/src/Actions/OmnichannelSubscriptionItemActions.php
+++ b/src/Actions/OmnichannelSubscriptionItemActions.php
@@ -10,7 +10,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -35,12 +34,10 @@ final class OmnichannelSubscriptionItemActions implements OmnichannelSubscriptio
     *   @param array<string, string> $headers
     *   @return ListOmniSubItemScheduleChangesOmnichannelSubscriptionItemResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function listOmniSubItemScheduleChanges(string $id, array $params = [], array $headers = []): ListOmniSubItemScheduleChangesOmnichannelSubscriptionItemResponse
     {

--- a/src/Actions/OmnichannelSubscriptionItemActions.php
+++ b/src/Actions/OmnichannelSubscriptionItemActions.php
@@ -9,6 +9,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class OmnichannelSubscriptionItemActions implements OmnichannelSubscriptionItemActionsInterface
 {
@@ -28,6 +34,13 @@ final class OmnichannelSubscriptionItemActions implements OmnichannelSubscriptio
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ListOmniSubItemScheduleChangesOmnichannelSubscriptionItemResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function listOmniSubItemScheduleChanges(string $id, array $params = [], array $headers = []): ListOmniSubItemScheduleChangesOmnichannelSubscriptionItemResponse
     {

--- a/src/Actions/OrderActions.php
+++ b/src/Actions/OrderActions.php
@@ -20,6 +20,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class OrderActions implements OrderActionsInterface
 {
@@ -126,6 +132,13 @@ final class OrderActions implements OrderActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListOrderResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListOrderResponse
     {
@@ -162,6 +175,13 @@ final class OrderActions implements OrderActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateOrderResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateOrderResponse
     {
@@ -244,6 +264,13 @@ final class OrderActions implements OrderActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ImportOrderOrderResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function importOrder(array $params, array $headers = []): ImportOrderOrderResponse
     {
@@ -271,6 +298,13 @@ final class OrderActions implements OrderActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return AssignOrderNumberOrderResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function assignOrderNumber(string $id, array $headers = []): AssignOrderNumberOrderResponse
     {
@@ -304,6 +338,13 @@ final class OrderActions implements OrderActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ResendOrderResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function resend(string $id, array $params = [], array $headers = []): ResendOrderResponse
     {
@@ -333,6 +374,13 @@ final class OrderActions implements OrderActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ReopenOrderResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function reopen(string $id, array $params = [], array $headers = []): ReopenOrderResponse
     {
@@ -363,6 +411,13 @@ final class OrderActions implements OrderActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return OrdersForInvoiceOrderResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function ordersForInvoice(string $id, array $params = [], array $headers = []): OrdersForInvoiceOrderResponse
     {
@@ -397,6 +452,13 @@ final class OrderActions implements OrderActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CancelOrderResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function cancel(string $id, array $params, array $headers = []): CancelOrderResponse
     {
@@ -424,6 +486,13 @@ final class OrderActions implements OrderActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveOrderResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveOrderResponse
     {
@@ -485,6 +554,13 @@ final class OrderActions implements OrderActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateOrderResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdateOrderResponse
     {
@@ -512,6 +588,13 @@ final class OrderActions implements OrderActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteOrderResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteOrderResponse
     {
@@ -545,6 +628,13 @@ final class OrderActions implements OrderActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CreateRefundableCreditNoteOrderResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createRefundableCreditNote(string $id, array $params, array $headers = []): CreateRefundableCreditNoteOrderResponse
     {

--- a/src/Actions/OrderActions.php
+++ b/src/Actions/OrderActions.php
@@ -21,7 +21,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -133,12 +132,10 @@ final class OrderActions implements OrderActionsInterface
     *   @param array<string, string> $headers
     *   @return ListOrderResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListOrderResponse
     {
@@ -176,12 +173,10 @@ final class OrderActions implements OrderActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateOrderResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateOrderResponse
     {
@@ -265,12 +260,10 @@ final class OrderActions implements OrderActionsInterface
     *   @param array<string, string> $headers
     *   @return ImportOrderOrderResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function importOrder(array $params, array $headers = []): ImportOrderOrderResponse
     {
@@ -299,12 +292,10 @@ final class OrderActions implements OrderActionsInterface
     *   @param array<string, string> $headers
     *   @return AssignOrderNumberOrderResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function assignOrderNumber(string $id, array $headers = []): AssignOrderNumberOrderResponse
     {
@@ -339,12 +330,10 @@ final class OrderActions implements OrderActionsInterface
     *   @param array<string, string> $headers
     *   @return ResendOrderResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function resend(string $id, array $params = [], array $headers = []): ResendOrderResponse
     {
@@ -375,12 +364,10 @@ final class OrderActions implements OrderActionsInterface
     *   @param array<string, string> $headers
     *   @return ReopenOrderResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function reopen(string $id, array $params = [], array $headers = []): ReopenOrderResponse
     {
@@ -412,12 +399,10 @@ final class OrderActions implements OrderActionsInterface
     *   @param array<string, string> $headers
     *   @return OrdersForInvoiceOrderResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function ordersForInvoice(string $id, array $params = [], array $headers = []): OrdersForInvoiceOrderResponse
     {
@@ -453,12 +438,10 @@ final class OrderActions implements OrderActionsInterface
     *   @param array<string, string> $headers
     *   @return CancelOrderResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function cancel(string $id, array $params, array $headers = []): CancelOrderResponse
     {
@@ -487,12 +470,10 @@ final class OrderActions implements OrderActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveOrderResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveOrderResponse
     {
@@ -555,12 +536,10 @@ final class OrderActions implements OrderActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateOrderResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdateOrderResponse
     {
@@ -589,12 +568,10 @@ final class OrderActions implements OrderActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteOrderResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteOrderResponse
     {
@@ -629,12 +606,10 @@ final class OrderActions implements OrderActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateRefundableCreditNoteOrderResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createRefundableCreditNote(string $id, array $params, array $headers = []): CreateRefundableCreditNoteOrderResponse
     {

--- a/src/Actions/PaymentIntentActions.php
+++ b/src/Actions/PaymentIntentActions.php
@@ -10,6 +10,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class PaymentIntentActions implements PaymentIntentActionsInterface
 {
@@ -26,6 +32,13 @@ final class PaymentIntentActions implements PaymentIntentActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrievePaymentIntentResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrievePaymentIntentResponse
     {
@@ -58,6 +71,13 @@ final class PaymentIntentActions implements PaymentIntentActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdatePaymentIntentResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdatePaymentIntentResponse
     {
@@ -95,6 +115,13 @@ final class PaymentIntentActions implements PaymentIntentActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreatePaymentIntentResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreatePaymentIntentResponse
     {

--- a/src/Actions/PaymentIntentActions.php
+++ b/src/Actions/PaymentIntentActions.php
@@ -11,7 +11,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -33,12 +32,10 @@ final class PaymentIntentActions implements PaymentIntentActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrievePaymentIntentResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrievePaymentIntentResponse
     {
@@ -72,12 +69,10 @@ final class PaymentIntentActions implements PaymentIntentActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdatePaymentIntentResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdatePaymentIntentResponse
     {
@@ -116,12 +111,10 @@ final class PaymentIntentActions implements PaymentIntentActionsInterface
     *   @param array<string, string> $headers
     *   @return CreatePaymentIntentResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreatePaymentIntentResponse
     {

--- a/src/Actions/PaymentScheduleSchemeActions.php
+++ b/src/Actions/PaymentScheduleSchemeActions.php
@@ -11,7 +11,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -33,12 +32,10 @@ final class PaymentScheduleSchemeActions implements PaymentScheduleSchemeActions
     *   @param array<string, string> $headers
     *   @return RetrievePaymentScheduleSchemeResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrievePaymentScheduleSchemeResponse
     {
@@ -74,12 +71,10 @@ final class PaymentScheduleSchemeActions implements PaymentScheduleSchemeActions
     *   @param array<string, string> $headers
     *   @return CreatePaymentScheduleSchemeResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreatePaymentScheduleSchemeResponse
     {
@@ -108,12 +103,10 @@ final class PaymentScheduleSchemeActions implements PaymentScheduleSchemeActions
     *   @param array<string, string> $headers
     *   @return DeletePaymentScheduleSchemeResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeletePaymentScheduleSchemeResponse
     {

--- a/src/Actions/PaymentScheduleSchemeActions.php
+++ b/src/Actions/PaymentScheduleSchemeActions.php
@@ -10,6 +10,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class PaymentScheduleSchemeActions implements PaymentScheduleSchemeActionsInterface
 {
@@ -26,6 +32,13 @@ final class PaymentScheduleSchemeActions implements PaymentScheduleSchemeActions
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrievePaymentScheduleSchemeResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrievePaymentScheduleSchemeResponse
     {
@@ -60,6 +73,13 @@ final class PaymentScheduleSchemeActions implements PaymentScheduleSchemeActions
     *   
     *   @param array<string, string> $headers
     *   @return CreatePaymentScheduleSchemeResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreatePaymentScheduleSchemeResponse
     {
@@ -87,6 +107,13 @@ final class PaymentScheduleSchemeActions implements PaymentScheduleSchemeActions
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeletePaymentScheduleSchemeResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeletePaymentScheduleSchemeResponse
     {

--- a/src/Actions/PaymentSourceActions.php
+++ b/src/Actions/PaymentSourceActions.php
@@ -24,6 +24,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class PaymentSourceActions implements PaymentSourceActionsInterface
 {
@@ -74,6 +80,13 @@ final class PaymentSourceActions implements PaymentSourceActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateUsingPermanentTokenPaymentSourceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createUsingPermanentToken(array $params, array $headers = []): CreateUsingPermanentTokenPaymentSourceResponse
     {
@@ -102,6 +115,13 @@ final class PaymentSourceActions implements PaymentSourceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeletePaymentSourceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeletePaymentSourceResponse
     {
@@ -149,6 +169,13 @@ final class PaymentSourceActions implements PaymentSourceActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateCardPaymentSourceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createCard(array $params, array $headers = []): CreateCardPaymentSourceResponse
     {
@@ -180,6 +207,13 @@ final class PaymentSourceActions implements PaymentSourceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return VerifyBankAccountPaymentSourceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function verifyBankAccount(string $id, array $params, array $headers = []): VerifyBankAccountPaymentSourceResponse
     {
@@ -247,6 +281,13 @@ final class PaymentSourceActions implements PaymentSourceActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListPaymentSourceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListPaymentSourceResponse
     {
@@ -275,6 +316,13 @@ final class PaymentSourceActions implements PaymentSourceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ExportPaymentSourcePaymentSourceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function exportPaymentSource(string $id, array $params, array $headers = []): ExportPaymentSourcePaymentSourceResponse
     {
@@ -315,6 +363,13 @@ final class PaymentSourceActions implements PaymentSourceActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateUsingPaymentIntentPaymentSourceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createUsingPaymentIntent(array $params, array $headers = []): CreateUsingPaymentIntentPaymentSourceResponse
     {
@@ -344,6 +399,13 @@ final class PaymentSourceActions implements PaymentSourceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrievePaymentSourceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrievePaymentSourceResponse
     {
@@ -377,6 +439,13 @@ final class PaymentSourceActions implements PaymentSourceActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateVoucherPaymentSourcePaymentSourceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createVoucherPaymentSource(array $params, array $headers = []): CreateVoucherPaymentSourcePaymentSourceResponse
     {
@@ -413,6 +482,13 @@ final class PaymentSourceActions implements PaymentSourceActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateUsingTempTokenPaymentSourceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createUsingTempToken(array $params, array $headers = []): CreateUsingTempTokenPaymentSourceResponse
     {
@@ -458,6 +534,13 @@ final class PaymentSourceActions implements PaymentSourceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateCardPaymentSourceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function updateCard(string $id, array $params = [], array $headers = []): UpdateCardPaymentSourceResponse
     {
@@ -489,6 +572,13 @@ final class PaymentSourceActions implements PaymentSourceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return SwitchGatewayAccountPaymentSourceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function switchGatewayAccount(string $id, array $params, array $headers = []): SwitchGatewayAccountPaymentSourceResponse
     {
@@ -520,6 +610,13 @@ final class PaymentSourceActions implements PaymentSourceActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateUsingTokenPaymentSourceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createUsingToken(array $params, array $headers = []): CreateUsingTokenPaymentSourceResponse
     {
@@ -547,6 +644,13 @@ final class PaymentSourceActions implements PaymentSourceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteLocalPaymentSourceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function deleteLocal(string $id, array $headers = []): DeleteLocalPaymentSourceResponse
     {
@@ -595,6 +699,13 @@ final class PaymentSourceActions implements PaymentSourceActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateBankAccountPaymentSourceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createBankAccount(array $params, array $headers = []): CreateBankAccountPaymentSourceResponse
     {
@@ -629,6 +740,13 @@ final class PaymentSourceActions implements PaymentSourceActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateBankAccountPaymentSourceResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function updateBankAccount(string $id, array $params = [], array $headers = []): UpdateBankAccountPaymentSourceResponse
     {

--- a/src/Actions/PaymentSourceActions.php
+++ b/src/Actions/PaymentSourceActions.php
@@ -25,7 +25,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -81,12 +80,10 @@ final class PaymentSourceActions implements PaymentSourceActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateUsingPermanentTokenPaymentSourceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createUsingPermanentToken(array $params, array $headers = []): CreateUsingPermanentTokenPaymentSourceResponse
     {
@@ -116,12 +113,10 @@ final class PaymentSourceActions implements PaymentSourceActionsInterface
     *   @param array<string, string> $headers
     *   @return DeletePaymentSourceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeletePaymentSourceResponse
     {
@@ -170,12 +165,10 @@ final class PaymentSourceActions implements PaymentSourceActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateCardPaymentSourceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createCard(array $params, array $headers = []): CreateCardPaymentSourceResponse
     {
@@ -208,12 +201,10 @@ final class PaymentSourceActions implements PaymentSourceActionsInterface
     *   @param array<string, string> $headers
     *   @return VerifyBankAccountPaymentSourceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function verifyBankAccount(string $id, array $params, array $headers = []): VerifyBankAccountPaymentSourceResponse
     {
@@ -282,12 +273,10 @@ final class PaymentSourceActions implements PaymentSourceActionsInterface
     *   @param array<string, string> $headers
     *   @return ListPaymentSourceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListPaymentSourceResponse
     {
@@ -317,12 +306,10 @@ final class PaymentSourceActions implements PaymentSourceActionsInterface
     *   @param array<string, string> $headers
     *   @return ExportPaymentSourcePaymentSourceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function exportPaymentSource(string $id, array $params, array $headers = []): ExportPaymentSourcePaymentSourceResponse
     {
@@ -364,12 +351,10 @@ final class PaymentSourceActions implements PaymentSourceActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateUsingPaymentIntentPaymentSourceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createUsingPaymentIntent(array $params, array $headers = []): CreateUsingPaymentIntentPaymentSourceResponse
     {
@@ -400,12 +385,10 @@ final class PaymentSourceActions implements PaymentSourceActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrievePaymentSourceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrievePaymentSourceResponse
     {
@@ -440,12 +423,10 @@ final class PaymentSourceActions implements PaymentSourceActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateVoucherPaymentSourcePaymentSourceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createVoucherPaymentSource(array $params, array $headers = []): CreateVoucherPaymentSourcePaymentSourceResponse
     {
@@ -483,12 +464,10 @@ final class PaymentSourceActions implements PaymentSourceActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateUsingTempTokenPaymentSourceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createUsingTempToken(array $params, array $headers = []): CreateUsingTempTokenPaymentSourceResponse
     {
@@ -535,12 +514,10 @@ final class PaymentSourceActions implements PaymentSourceActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateCardPaymentSourceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function updateCard(string $id, array $params = [], array $headers = []): UpdateCardPaymentSourceResponse
     {
@@ -573,12 +550,10 @@ final class PaymentSourceActions implements PaymentSourceActionsInterface
     *   @param array<string, string> $headers
     *   @return SwitchGatewayAccountPaymentSourceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function switchGatewayAccount(string $id, array $params, array $headers = []): SwitchGatewayAccountPaymentSourceResponse
     {
@@ -611,12 +586,10 @@ final class PaymentSourceActions implements PaymentSourceActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateUsingTokenPaymentSourceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createUsingToken(array $params, array $headers = []): CreateUsingTokenPaymentSourceResponse
     {
@@ -645,12 +618,10 @@ final class PaymentSourceActions implements PaymentSourceActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteLocalPaymentSourceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function deleteLocal(string $id, array $headers = []): DeleteLocalPaymentSourceResponse
     {
@@ -700,12 +671,10 @@ final class PaymentSourceActions implements PaymentSourceActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateBankAccountPaymentSourceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createBankAccount(array $params, array $headers = []): CreateBankAccountPaymentSourceResponse
     {
@@ -741,12 +710,10 @@ final class PaymentSourceActions implements PaymentSourceActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateBankAccountPaymentSourceResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function updateBankAccount(string $id, array $params = [], array $headers = []): UpdateBankAccountPaymentSourceResponse
     {

--- a/src/Actions/PaymentVoucherActions.php
+++ b/src/Actions/PaymentVoucherActions.php
@@ -13,7 +13,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -48,12 +47,10 @@ final class PaymentVoucherActions implements PaymentVoucherActionsInterface
     *   @param array<string, string> $headers
     *   @return PaymentVouchersForCustomerPaymentVoucherResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function paymentVouchersForCustomer(string $id, array $params = [], array $headers = []): PaymentVouchersForCustomerPaymentVoucherResponse
     {
@@ -94,12 +91,10 @@ final class PaymentVoucherActions implements PaymentVoucherActionsInterface
     *   @param array<string, string> $headers
     *   @return PaymentVouchersForInvoicePaymentVoucherResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function paymentVouchersForInvoice(string $id, array $params = [], array $headers = []): PaymentVouchersForInvoicePaymentVoucherResponse
     {
@@ -127,12 +122,10 @@ final class PaymentVoucherActions implements PaymentVoucherActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrievePaymentVoucherResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrievePaymentVoucherResponse
     {
@@ -168,12 +161,10 @@ final class PaymentVoucherActions implements PaymentVoucherActionsInterface
     *   @param array<string, string> $headers
     *   @return CreatePaymentVoucherResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreatePaymentVoucherResponse
     {

--- a/src/Actions/PaymentVoucherActions.php
+++ b/src/Actions/PaymentVoucherActions.php
@@ -12,6 +12,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class PaymentVoucherActions implements PaymentVoucherActionsInterface
 {
@@ -41,6 +47,13 @@ final class PaymentVoucherActions implements PaymentVoucherActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return PaymentVouchersForCustomerPaymentVoucherResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function paymentVouchersForCustomer(string $id, array $params = [], array $headers = []): PaymentVouchersForCustomerPaymentVoucherResponse
     {
@@ -80,6 +93,13 @@ final class PaymentVoucherActions implements PaymentVoucherActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return PaymentVouchersForInvoicePaymentVoucherResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function paymentVouchersForInvoice(string $id, array $params = [], array $headers = []): PaymentVouchersForInvoicePaymentVoucherResponse
     {
@@ -106,6 +126,13 @@ final class PaymentVoucherActions implements PaymentVoucherActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrievePaymentVoucherResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrievePaymentVoucherResponse
     {
@@ -140,6 +167,13 @@ final class PaymentVoucherActions implements PaymentVoucherActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreatePaymentVoucherResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreatePaymentVoucherResponse
     {

--- a/src/Actions/PlanActions.php
+++ b/src/Actions/PlanActions.php
@@ -16,7 +16,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -38,12 +37,10 @@ final class PlanActions implements PlanActionsInterface
     *   @param array<string, string> $headers
     *   @return UnarchivePlanResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function unarchive(string $id, array $headers = []): UnarchivePlanResponse
     {
@@ -71,12 +68,10 @@ final class PlanActions implements PlanActionsInterface
     *   @param array<string, string> $headers
     *   @return DeletePlanResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeletePlanResponse
     {
@@ -109,12 +104,10 @@ final class PlanActions implements PlanActionsInterface
     *   @param array<string, string> $headers
     *   @return CopyPlanResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function copy(array $params, array $headers = []): CopyPlanResponse
     {
@@ -247,12 +240,10 @@ final class PlanActions implements PlanActionsInterface
     *   @param array<string, string> $headers
     *   @return ListPlanResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListPlanResponse
     {
@@ -358,12 +349,10 @@ final class PlanActions implements PlanActionsInterface
     *   @param array<string, string> $headers
     *   @return CreatePlanResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreatePlanResponse
     {
@@ -393,12 +382,10 @@ final class PlanActions implements PlanActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrievePlanResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrievePlanResponse
     {
@@ -499,12 +486,10 @@ final class PlanActions implements PlanActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdatePlanResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params, array $headers = []): UpdatePlanResponse
     {

--- a/src/Actions/PlanActions.php
+++ b/src/Actions/PlanActions.php
@@ -15,6 +15,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class PlanActions implements PlanActionsInterface
 {
@@ -31,6 +37,13 @@ final class PlanActions implements PlanActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UnarchivePlanResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function unarchive(string $id, array $headers = []): UnarchivePlanResponse
     {
@@ -57,6 +70,13 @@ final class PlanActions implements PlanActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeletePlanResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeletePlanResponse
     {
@@ -88,6 +108,13 @@ final class PlanActions implements PlanActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CopyPlanResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function copy(array $params, array $headers = []): CopyPlanResponse
     {
@@ -219,6 +246,13 @@ final class PlanActions implements PlanActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListPlanResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListPlanResponse
     {
@@ -323,6 +357,13 @@ final class PlanActions implements PlanActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreatePlanResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreatePlanResponse
     {
@@ -351,6 +392,13 @@ final class PlanActions implements PlanActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrievePlanResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrievePlanResponse
     {
@@ -450,6 +498,13 @@ final class PlanActions implements PlanActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdatePlanResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params, array $headers = []): UpdatePlanResponse
     {

--- a/src/Actions/PortalSessionActions.php
+++ b/src/Actions/PortalSessionActions.php
@@ -12,7 +12,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -40,12 +39,10 @@ final class PortalSessionActions implements PortalSessionActionsInterface
     *   @param array<string, string> $headers
     *   @return CreatePortalSessionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreatePortalSessionResponse
     {
@@ -76,12 +73,10 @@ final class PortalSessionActions implements PortalSessionActionsInterface
     *   @param array<string, string> $headers
     *   @return ActivatePortalSessionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function activate(string $id, array $params, array $headers = []): ActivatePortalSessionResponse
     {
@@ -110,12 +105,10 @@ final class PortalSessionActions implements PortalSessionActionsInterface
     *   @param array<string, string> $headers
     *   @return LogoutPortalSessionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function logout(string $id, array $headers = []): LogoutPortalSessionResponse
     {
@@ -143,12 +136,10 @@ final class PortalSessionActions implements PortalSessionActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrievePortalSessionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrievePortalSessionResponse
     {

--- a/src/Actions/PortalSessionActions.php
+++ b/src/Actions/PortalSessionActions.php
@@ -11,6 +11,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class PortalSessionActions implements PortalSessionActionsInterface
 {
@@ -33,6 +39,13 @@ final class PortalSessionActions implements PortalSessionActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreatePortalSessionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreatePortalSessionResponse
     {
@@ -62,6 +75,13 @@ final class PortalSessionActions implements PortalSessionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ActivatePortalSessionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function activate(string $id, array $params, array $headers = []): ActivatePortalSessionResponse
     {
@@ -89,6 +109,13 @@ final class PortalSessionActions implements PortalSessionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return LogoutPortalSessionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function logout(string $id, array $headers = []): LogoutPortalSessionResponse
     {
@@ -115,6 +142,13 @@ final class PortalSessionActions implements PortalSessionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrievePortalSessionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrievePortalSessionResponse
     {

--- a/src/Actions/PriceVariantActions.php
+++ b/src/Actions/PriceVariantActions.php
@@ -13,6 +13,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class PriceVariantActions implements PriceVariantActionsInterface
 {
@@ -29,6 +35,13 @@ final class PriceVariantActions implements PriceVariantActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeletePriceVariantResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeletePriceVariantResponse
     {
@@ -101,6 +114,13 @@ final class PriceVariantActions implements PriceVariantActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListPriceVariantResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListPriceVariantResponse
     {
@@ -138,6 +158,13 @@ final class PriceVariantActions implements PriceVariantActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreatePriceVariantResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreatePriceVariantResponse
     {
@@ -165,6 +192,13 @@ final class PriceVariantActions implements PriceVariantActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrievePriceVariantResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrievePriceVariantResponse
     {
@@ -200,6 +234,13 @@ final class PriceVariantActions implements PriceVariantActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdatePriceVariantResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params, array $headers = []): UpdatePriceVariantResponse
     {

--- a/src/Actions/PriceVariantActions.php
+++ b/src/Actions/PriceVariantActions.php
@@ -14,7 +14,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -36,12 +35,10 @@ final class PriceVariantActions implements PriceVariantActionsInterface
     *   @param array<string, string> $headers
     *   @return DeletePriceVariantResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeletePriceVariantResponse
     {
@@ -115,12 +112,10 @@ final class PriceVariantActions implements PriceVariantActionsInterface
     *   @param array<string, string> $headers
     *   @return ListPriceVariantResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListPriceVariantResponse
     {
@@ -159,12 +154,10 @@ final class PriceVariantActions implements PriceVariantActionsInterface
     *   @param array<string, string> $headers
     *   @return CreatePriceVariantResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreatePriceVariantResponse
     {
@@ -193,12 +186,10 @@ final class PriceVariantActions implements PriceVariantActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrievePriceVariantResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrievePriceVariantResponse
     {
@@ -235,12 +226,10 @@ final class PriceVariantActions implements PriceVariantActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdatePriceVariantResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params, array $headers = []): UpdatePriceVariantResponse
     {

--- a/src/Actions/PricingPageSessionActions.php
+++ b/src/Actions/PricingPageSessionActions.php
@@ -10,7 +10,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -52,12 +51,10 @@ final class PricingPageSessionActions implements PricingPageSessionActionsInterf
     *   @param array<string, string> $headers
     *   @return CreateForExistingSubscriptionPricingPageSessionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createForExistingSubscription(array $params, array $headers = []): CreateForExistingSubscriptionPricingPageSessionResponse
     {
@@ -148,12 +145,10 @@ final class PricingPageSessionActions implements PricingPageSessionActionsInterf
     *   @param array<string, string> $headers
     *   @return CreateForNewSubscriptionPricingPageSessionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createForNewSubscription(array $params, array $headers = []): CreateForNewSubscriptionPricingPageSessionResponse
     {

--- a/src/Actions/PricingPageSessionActions.php
+++ b/src/Actions/PricingPageSessionActions.php
@@ -9,6 +9,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class PricingPageSessionActions implements PricingPageSessionActionsInterface
 {
@@ -45,6 +51,13 @@ final class PricingPageSessionActions implements PricingPageSessionActionsInterf
     *   
     *   @param array<string, string> $headers
     *   @return CreateForExistingSubscriptionPricingPageSessionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createForExistingSubscription(array $params, array $headers = []): CreateForExistingSubscriptionPricingPageSessionResponse
     {
@@ -134,6 +147,13 @@ final class PricingPageSessionActions implements PricingPageSessionActionsInterf
     *   
     *   @param array<string, string> $headers
     *   @return CreateForNewSubscriptionPricingPageSessionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createForNewSubscription(array $params, array $headers = []): CreateForNewSubscriptionPricingPageSessionResponse
     {

--- a/src/Actions/PromotionalCreditActions.php
+++ b/src/Actions/PromotionalCreditActions.php
@@ -14,7 +14,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -36,12 +35,10 @@ final class PromotionalCreditActions implements PromotionalCreditActionsInterfac
     *   @param array<string, string> $headers
     *   @return RetrievePromotionalCreditResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrievePromotionalCreditResponse
     {
@@ -93,12 +90,10 @@ final class PromotionalCreditActions implements PromotionalCreditActionsInterfac
     *   @param array<string, string> $headers
     *   @return ListPromotionalCreditResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListPromotionalCreditResponse
     {
@@ -134,12 +129,10 @@ final class PromotionalCreditActions implements PromotionalCreditActionsInterfac
     *   @param array<string, string> $headers
     *   @return DeductPromotionalCreditResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function deduct(array $params, array $headers = []): DeductPromotionalCreditResponse
     {
@@ -176,12 +169,10 @@ final class PromotionalCreditActions implements PromotionalCreditActionsInterfac
     *   @param array<string, string> $headers
     *   @return SetPromotionalCreditResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function set(array $params, array $headers = []): SetPromotionalCreditResponse
     {
@@ -218,12 +209,10 @@ final class PromotionalCreditActions implements PromotionalCreditActionsInterfac
     *   @param array<string, string> $headers
     *   @return AddPromotionalCreditResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function add(array $params, array $headers = []): AddPromotionalCreditResponse
     {

--- a/src/Actions/PromotionalCreditActions.php
+++ b/src/Actions/PromotionalCreditActions.php
@@ -13,6 +13,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class PromotionalCreditActions implements PromotionalCreditActionsInterface
 {
@@ -29,6 +35,13 @@ final class PromotionalCreditActions implements PromotionalCreditActionsInterfac
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrievePromotionalCreditResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrievePromotionalCreditResponse
     {
@@ -79,6 +92,13 @@ final class PromotionalCreditActions implements PromotionalCreditActionsInterfac
     *   
     *   @param array<string, string> $headers
     *   @return ListPromotionalCreditResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListPromotionalCreditResponse
     {
@@ -113,6 +133,13 @@ final class PromotionalCreditActions implements PromotionalCreditActionsInterfac
     *   
     *   @param array<string, string> $headers
     *   @return DeductPromotionalCreditResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function deduct(array $params, array $headers = []): DeductPromotionalCreditResponse
     {
@@ -148,6 +175,13 @@ final class PromotionalCreditActions implements PromotionalCreditActionsInterfac
     *   
     *   @param array<string, string> $headers
     *   @return SetPromotionalCreditResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function set(array $params, array $headers = []): SetPromotionalCreditResponse
     {
@@ -183,6 +217,13 @@ final class PromotionalCreditActions implements PromotionalCreditActionsInterfac
     *   
     *   @param array<string, string> $headers
     *   @return AddPromotionalCreditResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function add(array $params, array $headers = []): AddPromotionalCreditResponse
     {

--- a/src/Actions/PurchaseActions.php
+++ b/src/Actions/PurchaseActions.php
@@ -9,6 +9,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class PurchaseActions implements PurchaseActionsInterface
 {
@@ -103,6 +109,13 @@ final class PurchaseActions implements PurchaseActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreatePurchaseResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreatePurchaseResponse
     {
@@ -208,6 +221,13 @@ final class PurchaseActions implements PurchaseActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return EstimatePurchaseResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function estimate(array $params, array $headers = []): EstimatePurchaseResponse
     {

--- a/src/Actions/PurchaseActions.php
+++ b/src/Actions/PurchaseActions.php
@@ -10,7 +10,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -110,12 +109,10 @@ final class PurchaseActions implements PurchaseActionsInterface
     *   @param array<string, string> $headers
     *   @return CreatePurchaseResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreatePurchaseResponse
     {
@@ -222,12 +219,10 @@ final class PurchaseActions implements PurchaseActionsInterface
     *   @param array<string, string> $headers
     *   @return EstimatePurchaseResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function estimate(array $params, array $headers = []): EstimatePurchaseResponse
     {

--- a/src/Actions/QuoteActions.php
+++ b/src/Actions/QuoteActions.php
@@ -28,6 +28,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class QuoteActions implements QuoteActionsInterface
 {
@@ -146,6 +152,13 @@ final class QuoteActions implements QuoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CreateSubItemsForCustomerQuoteQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createSubItemsForCustomerQuote(string $id, array $params, array $headers = []): CreateSubItemsForCustomerQuoteQuoteResponse
     {
@@ -173,6 +186,13 @@ final class QuoteActions implements QuoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveQuoteResponse
     {
@@ -299,6 +319,13 @@ final class QuoteActions implements QuoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return EditCreateSubCustomerQuoteForItemsQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function editCreateSubCustomerQuoteForItems(string $id, array $params, array $headers = []): EditCreateSubCustomerQuoteForItemsQuoteResponse
     {
@@ -329,6 +356,13 @@ final class QuoteActions implements QuoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateStatusQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function updateStatus(string $id, array $params, array $headers = []): UpdateStatusQuoteResponse
     {
@@ -473,6 +507,13 @@ final class QuoteActions implements QuoteActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return UpdateSubscriptionQuoteForItemsQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function updateSubscriptionQuoteForItems(array $params, array $headers = []): UpdateSubscriptionQuoteForItemsQuoteResponse
     {
@@ -503,6 +544,13 @@ final class QuoteActions implements QuoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return QuoteLineGroupsForQuoteQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function quoteLineGroupsForQuote(string $id, array $params = [], array $headers = []): QuoteLineGroupsForQuoteQuoteResponse
     {
@@ -531,6 +579,13 @@ final class QuoteActions implements QuoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ExtendExpiryDateQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function extendExpiryDate(string $id, array $params, array $headers = []): ExtendExpiryDateQuoteResponse
     {
@@ -637,6 +692,13 @@ final class QuoteActions implements QuoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return EditForChargeItemsAndChargesQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function editForChargeItemsAndCharges(string $id, array $params, array $headers = []): EditForChargeItemsAndChargesQuoteResponse
     {
@@ -779,6 +841,13 @@ final class QuoteActions implements QuoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return EditUpdateSubscriptionQuoteForItemsQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function editUpdateSubscriptionQuoteForItems(string $id, array $params, array $headers = []): EditUpdateSubscriptionQuoteForItemsQuoteResponse
     {
@@ -854,6 +923,13 @@ final class QuoteActions implements QuoteActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListQuoteResponse
     {
@@ -883,6 +959,13 @@ final class QuoteActions implements QuoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return PdfQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function pdf(string $id, array $params = [], array $headers = []): PdfQuoteResponse
     {
@@ -921,6 +1004,13 @@ final class QuoteActions implements QuoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ConvertQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function convert(string $id, array $params = [], array $headers = []): ConvertQuoteResponse
     {
@@ -1029,6 +1119,13 @@ final class QuoteActions implements QuoteActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateForChargeItemsAndChargesQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createForChargeItemsAndCharges(array $params, array $headers = []): CreateForChargeItemsAndChargesQuoteResponse
     {
@@ -1058,6 +1155,13 @@ final class QuoteActions implements QuoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $params = [], array $headers = []): DeleteQuoteResponse
     {
@@ -1130,6 +1234,13 @@ final class QuoteActions implements QuoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return EditOneTimeQuoteQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function editOneTimeQuote(string $id, array $params = [], array $headers = []): EditOneTimeQuoteQuoteResponse
     {
@@ -1249,6 +1360,13 @@ final class QuoteActions implements QuoteActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return UpdateSubscriptionQuoteQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function updateSubscriptionQuote(array $params, array $headers = []): UpdateSubscriptionQuoteQuoteResponse
     {
@@ -1323,6 +1441,13 @@ final class QuoteActions implements QuoteActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateForOnetimeChargesQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createForOnetimeCharges(array $params, array $headers = []): CreateForOnetimeChargesQuoteResponse
     {
@@ -1413,6 +1538,13 @@ final class QuoteActions implements QuoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CreateSubForCustomerQuoteQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createSubForCustomerQuote(string $id, array $params, array $headers = []): CreateSubForCustomerQuoteQuoteResponse
     {
@@ -1530,6 +1662,13 @@ final class QuoteActions implements QuoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return EditUpdateSubscriptionQuoteQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function editUpdateSubscriptionQuote(string $id, array $params = [], array $headers = []): EditUpdateSubscriptionQuoteQuoteResponse
     {
@@ -1619,6 +1758,13 @@ final class QuoteActions implements QuoteActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return EditCreateSubForCustomerQuoteQuoteResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function editCreateSubForCustomerQuote(string $id, array $params, array $headers = []): EditCreateSubForCustomerQuoteQuoteResponse
     {

--- a/src/Actions/QuoteActions.php
+++ b/src/Actions/QuoteActions.php
@@ -29,7 +29,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -153,12 +152,10 @@ final class QuoteActions implements QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateSubItemsForCustomerQuoteQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createSubItemsForCustomerQuote(string $id, array $params, array $headers = []): CreateSubItemsForCustomerQuoteQuoteResponse
     {
@@ -187,12 +184,10 @@ final class QuoteActions implements QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveQuoteResponse
     {
@@ -320,12 +315,10 @@ final class QuoteActions implements QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return EditCreateSubCustomerQuoteForItemsQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function editCreateSubCustomerQuoteForItems(string $id, array $params, array $headers = []): EditCreateSubCustomerQuoteForItemsQuoteResponse
     {
@@ -357,12 +350,10 @@ final class QuoteActions implements QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateStatusQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function updateStatus(string $id, array $params, array $headers = []): UpdateStatusQuoteResponse
     {
@@ -508,12 +499,10 @@ final class QuoteActions implements QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateSubscriptionQuoteForItemsQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function updateSubscriptionQuoteForItems(array $params, array $headers = []): UpdateSubscriptionQuoteForItemsQuoteResponse
     {
@@ -545,12 +534,10 @@ final class QuoteActions implements QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return QuoteLineGroupsForQuoteQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function quoteLineGroupsForQuote(string $id, array $params = [], array $headers = []): QuoteLineGroupsForQuoteQuoteResponse
     {
@@ -580,12 +567,10 @@ final class QuoteActions implements QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return ExtendExpiryDateQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function extendExpiryDate(string $id, array $params, array $headers = []): ExtendExpiryDateQuoteResponse
     {
@@ -693,12 +678,10 @@ final class QuoteActions implements QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return EditForChargeItemsAndChargesQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function editForChargeItemsAndCharges(string $id, array $params, array $headers = []): EditForChargeItemsAndChargesQuoteResponse
     {
@@ -842,12 +825,10 @@ final class QuoteActions implements QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return EditUpdateSubscriptionQuoteForItemsQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function editUpdateSubscriptionQuoteForItems(string $id, array $params, array $headers = []): EditUpdateSubscriptionQuoteForItemsQuoteResponse
     {
@@ -924,12 +905,10 @@ final class QuoteActions implements QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return ListQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListQuoteResponse
     {
@@ -960,12 +939,10 @@ final class QuoteActions implements QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return PdfQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function pdf(string $id, array $params = [], array $headers = []): PdfQuoteResponse
     {
@@ -1005,12 +982,10 @@ final class QuoteActions implements QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return ConvertQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function convert(string $id, array $params = [], array $headers = []): ConvertQuoteResponse
     {
@@ -1120,12 +1095,10 @@ final class QuoteActions implements QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateForChargeItemsAndChargesQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createForChargeItemsAndCharges(array $params, array $headers = []): CreateForChargeItemsAndChargesQuoteResponse
     {
@@ -1156,12 +1129,10 @@ final class QuoteActions implements QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $params = [], array $headers = []): DeleteQuoteResponse
     {
@@ -1235,12 +1206,10 @@ final class QuoteActions implements QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return EditOneTimeQuoteQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function editOneTimeQuote(string $id, array $params = [], array $headers = []): EditOneTimeQuoteQuoteResponse
     {
@@ -1361,12 +1330,10 @@ final class QuoteActions implements QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateSubscriptionQuoteQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function updateSubscriptionQuote(array $params, array $headers = []): UpdateSubscriptionQuoteQuoteResponse
     {
@@ -1442,12 +1409,10 @@ final class QuoteActions implements QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateForOnetimeChargesQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createForOnetimeCharges(array $params, array $headers = []): CreateForOnetimeChargesQuoteResponse
     {
@@ -1539,12 +1504,10 @@ final class QuoteActions implements QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateSubForCustomerQuoteQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createSubForCustomerQuote(string $id, array $params, array $headers = []): CreateSubForCustomerQuoteQuoteResponse
     {
@@ -1663,12 +1626,10 @@ final class QuoteActions implements QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return EditUpdateSubscriptionQuoteQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function editUpdateSubscriptionQuote(string $id, array $params = [], array $headers = []): EditUpdateSubscriptionQuoteQuoteResponse
     {
@@ -1759,12 +1720,10 @@ final class QuoteActions implements QuoteActionsInterface
     *   @param array<string, string> $headers
     *   @return EditCreateSubForCustomerQuoteQuoteResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function editCreateSubForCustomerQuote(string $id, array $params, array $headers = []): EditCreateSubForCustomerQuoteQuoteResponse
     {

--- a/src/Actions/RampActions.php
+++ b/src/Actions/RampActions.php
@@ -14,7 +14,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -36,12 +35,10 @@ final class RampActions implements RampActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveRampResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveRampResponse
     {
@@ -117,12 +114,10 @@ final class RampActions implements RampActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateForSubscriptionRampResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createForSubscription(string $id, array $params, array $headers = []): CreateForSubscriptionRampResponse
     {
@@ -179,12 +174,10 @@ final class RampActions implements RampActionsInterface
     *   @param array<string, string> $headers
     *   @return ListRampResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params, array $headers = []): ListRampResponse
     {
@@ -261,12 +254,10 @@ final class RampActions implements RampActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateRampResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params, array $headers = []): UpdateRampResponse
     {
@@ -295,12 +286,10 @@ final class RampActions implements RampActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteRampResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteRampResponse
     {

--- a/src/Actions/RampActions.php
+++ b/src/Actions/RampActions.php
@@ -13,6 +13,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class RampActions implements RampActionsInterface
 {
@@ -29,6 +35,13 @@ final class RampActions implements RampActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveRampResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveRampResponse
     {
@@ -103,6 +116,13 @@ final class RampActions implements RampActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CreateForSubscriptionRampResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createForSubscription(string $id, array $params, array $headers = []): CreateForSubscriptionRampResponse
     {
@@ -131,12 +151,12 @@ final class RampActions implements RampActionsInterface
     *     offset?: string,
     *     include_deleted?: bool,
     *     status?: array{
-    *     is?: mixed,
     *     in?: mixed,
+    *     is?: mixed,
     *     },
     * subscription_id?: array{
-    *     is?: mixed,
     *     in?: mixed,
+    *     is?: mixed,
     *     },
     * effective_from?: array{
     *     after?: mixed,
@@ -158,6 +178,13 @@ final class RampActions implements RampActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListRampResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params, array $headers = []): ListRampResponse
     {
@@ -233,6 +260,13 @@ final class RampActions implements RampActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateRampResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params, array $headers = []): UpdateRampResponse
     {
@@ -260,6 +294,13 @@ final class RampActions implements RampActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteRampResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteRampResponse
     {

--- a/src/Actions/RecordedPurchaseActions.php
+++ b/src/Actions/RecordedPurchaseActions.php
@@ -9,6 +9,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class RecordedPurchaseActions implements RecordedPurchaseActionsInterface
 {
@@ -25,6 +31,13 @@ final class RecordedPurchaseActions implements RecordedPurchaseActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveRecordedPurchaseResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveRecordedPurchaseResponse
     {
@@ -68,6 +81,13 @@ final class RecordedPurchaseActions implements RecordedPurchaseActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateRecordedPurchaseResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateRecordedPurchaseResponse
     {

--- a/src/Actions/RecordedPurchaseActions.php
+++ b/src/Actions/RecordedPurchaseActions.php
@@ -10,7 +10,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -32,12 +31,10 @@ final class RecordedPurchaseActions implements RecordedPurchaseActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveRecordedPurchaseResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveRecordedPurchaseResponse
     {
@@ -82,12 +79,10 @@ final class RecordedPurchaseActions implements RecordedPurchaseActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateRecordedPurchaseResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateRecordedPurchaseResponse
     {

--- a/src/Actions/ResourceMigrationActions.php
+++ b/src/Actions/ResourceMigrationActions.php
@@ -9,7 +9,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -35,12 +34,10 @@ final class ResourceMigrationActions implements ResourceMigrationActionsInterfac
     *   @param array<string, string> $headers
     *   @return RetrieveLatestResourceMigrationResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieveLatest(array $params, array $headers = []): RetrieveLatestResourceMigrationResponse
     {

--- a/src/Actions/ResourceMigrationActions.php
+++ b/src/Actions/ResourceMigrationActions.php
@@ -8,6 +8,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class ResourceMigrationActions implements ResourceMigrationActionsInterface
 {
@@ -28,6 +34,13 @@ final class ResourceMigrationActions implements ResourceMigrationActionsInterfac
     *   
     *   @param array<string, string> $headers
     *   @return RetrieveLatestResourceMigrationResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieveLatest(array $params, array $headers = []): RetrieveLatestResourceMigrationResponse
     {

--- a/src/Actions/RuleActions.php
+++ b/src/Actions/RuleActions.php
@@ -8,6 +8,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class RuleActions implements RuleActionsInterface
 {
@@ -24,6 +30,13 @@ final class RuleActions implements RuleActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveRuleResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveRuleResponse
     {

--- a/src/Actions/RuleActions.php
+++ b/src/Actions/RuleActions.php
@@ -9,7 +9,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -31,12 +30,10 @@ final class RuleActions implements RuleActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveRuleResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveRuleResponse
     {

--- a/src/Actions/SiteMigrationDetailActions.php
+++ b/src/Actions/SiteMigrationDetailActions.php
@@ -10,7 +10,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -62,12 +61,10 @@ final class SiteMigrationDetailActions implements SiteMigrationDetailActionsInte
     *   @param array<string, string> $headers
     *   @return ListSiteMigrationDetailResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListSiteMigrationDetailResponse
     {

--- a/src/Actions/SiteMigrationDetailActions.php
+++ b/src/Actions/SiteMigrationDetailActions.php
@@ -9,6 +9,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class SiteMigrationDetailActions implements SiteMigrationDetailActionsInterface
 {
@@ -55,6 +61,13 @@ final class SiteMigrationDetailActions implements SiteMigrationDetailActionsInte
     *   
     *   @param array<string, string> $headers
     *   @return ListSiteMigrationDetailResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListSiteMigrationDetailResponse
     {

--- a/src/Actions/SubscriptionActions.php
+++ b/src/Actions/SubscriptionActions.php
@@ -45,6 +45,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class SubscriptionActions implements SubscriptionActionsInterface
 {
@@ -65,6 +71,13 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RemoveAdvanceInvoiceScheduleSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function removeAdvanceInvoiceSchedule(string $id, array $params = [], array $headers = []): RemoveAdvanceInvoiceScheduleSubscriptionResponse
     {
@@ -266,6 +279,13 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateForItemsSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function updateForItems(string $id, array $params, array $headers = []): UpdateForItemsSubscriptionResponse
     {
@@ -297,6 +317,13 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RemoveCouponsSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function removeCoupons(string $id, array $params = [], array $headers = []): RemoveCouponsSubscriptionResponse
     {
@@ -339,6 +366,13 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ResumeSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function resume(string $id, array $params = [], array $headers = []): ResumeSubscriptionResponse
     {
@@ -386,6 +420,13 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CancelForItemsSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function cancelForItems(string $id, array $params = [], array $headers = []): CancelForItemsSubscriptionResponse
     {
@@ -418,6 +459,13 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RegenerateInvoiceSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function regenerateInvoice(string $id, array $params = [], array $headers = []): RegenerateInvoiceSubscriptionResponse
     {
@@ -573,6 +621,13 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListSubscriptionResponse
     {
@@ -791,6 +846,13 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateSubscriptionResponse
     {
@@ -825,6 +887,13 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return MoveSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function move(string $id, array $params, array $headers = []): MoveSubscriptionResponse
     {
@@ -855,6 +924,13 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return SubscriptionsForCustomerSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function subscriptionsForCustomer(string $id, array $params = [], array $headers = []): SubscriptionsForCustomerSubscriptionResponse
     {
@@ -968,6 +1044,13 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CreateForCustomerSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createForCustomer(string $id, array $params, array $headers = []): CreateForCustomerSubscriptionResponse
     {
@@ -1100,6 +1183,13 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ImportForItemsSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function importForItems(string $id, array $params, array $headers = []): ImportForItemsSubscriptionResponse
     {
@@ -1128,6 +1218,13 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveAdvanceInvoiceScheduleSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieveAdvanceInvoiceSchedule(string $id, array $headers = []): RetrieveAdvanceInvoiceScheduleSubscriptionResponse
     {
@@ -1160,6 +1257,13 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RemoveScheduledCancellationSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function removeScheduledCancellation(string $id, array $params = [], array $headers = []): RemoveScheduledCancellationSubscriptionResponse
     {
@@ -1187,6 +1291,13 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveWithScheduledChangesSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieveWithScheduledChanges(string $id, array $headers = []): RetrieveWithScheduledChangesSubscriptionResponse
     {
@@ -1239,6 +1350,13 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ReactivateSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function reactivate(string $id, array $params = [], array $headers = []): ReactivateSubscriptionResponse
     {
@@ -1281,6 +1399,13 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ChargeFutureRenewalsSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function chargeFutureRenewals(string $id, array $params = [], array $headers = []): ChargeFutureRenewalsSubscriptionResponse
     {
@@ -1317,6 +1442,13 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return AddChargeAtTermEndSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function addChargeAtTermEnd(string $id, array $params, array $headers = []): AddChargeAtTermEndSubscriptionResponse
     {
@@ -1344,6 +1476,13 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RemoveScheduledChangesSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function removeScheduledChanges(string $id, array $headers = []): RemoveScheduledChangesSubscriptionResponse
     {
@@ -1374,6 +1513,13 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ChangeTermEndSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function changeTermEnd(string $id, array $params, array $headers = []): ChangeTermEndSubscriptionResponse
     {
@@ -1401,6 +1547,13 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteSubscriptionResponse
     {
@@ -1535,6 +1688,13 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CreateWithItemsSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createWithItems(string $id, array $params, array $headers = []): CreateWithItemsSubscriptionResponse
     {
@@ -1600,6 +1760,13 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ImportUnbilledChargesSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function importUnbilledCharges(string $id, array $params, array $headers = []): ImportUnbilledChargesSubscriptionResponse
     {
@@ -1627,6 +1794,13 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RemoveScheduledResumptionSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function removeScheduledResumption(string $id, array $headers = []): RemoveScheduledResumptionSubscriptionResponse
     {
@@ -1653,6 +1827,13 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveSubscriptionResponse
     {
@@ -1828,6 +2009,13 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdateSubscriptionResponse
     {
@@ -1873,6 +2061,13 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ImportContractTermSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function importContractTerm(string $id, array $params = [], array $headers = []): ImportContractTermSubscriptionResponse
     {
@@ -1903,6 +2098,13 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return OverrideBillingProfileSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function overrideBillingProfile(string $id, array $params = [], array $headers = []): OverrideBillingProfileSubscriptionResponse
     {
@@ -1930,6 +2132,13 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RemoveScheduledPauseSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function removeScheduledPause(string $id, array $headers = []): RemoveScheduledPauseSubscriptionResponse
     {
@@ -1970,6 +2179,13 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return EditAdvanceInvoiceScheduleSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function editAdvanceInvoiceSchedule(string $id, array $params = [], array $headers = []): EditAdvanceInvoiceScheduleSubscriptionResponse
     {
@@ -2000,6 +2216,13 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ListDiscountsSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function listDiscounts(string $id, array $params = [], array $headers = []): ListDiscountsSubscriptionResponse
     {
@@ -2033,6 +2256,13 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ContractTermsForSubscriptionSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function contractTermsForSubscription(string $id, array $params = [], array $headers = []): ContractTermsForSubscriptionSubscriptionResponse
     {
@@ -2066,6 +2296,13 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return PauseSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function pause(string $id, array $params = [], array $headers = []): PauseSubscriptionResponse
     {
@@ -2179,6 +2416,13 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ImportForCustomerSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function importForCustomer(string $id, array $params, array $headers = []): ImportForCustomerSubscriptionResponse
     {
@@ -2357,6 +2601,13 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ImportSubscriptionSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function importSubscription(array $params, array $headers = []): ImportSubscriptionSubscriptionResponse
     {
@@ -2403,6 +2654,13 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CancelSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function cancel(string $id, array $params = [], array $headers = []): CancelSubscriptionResponse
     {
@@ -2438,6 +2696,13 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ChargeAddonAtTermEndSubscriptionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function chargeAddonAtTermEnd(string $id, array $params, array $headers = []): ChargeAddonAtTermEndSubscriptionResponse
     {

--- a/src/Actions/SubscriptionActions.php
+++ b/src/Actions/SubscriptionActions.php
@@ -46,7 +46,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -72,12 +71,10 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return RemoveAdvanceInvoiceScheduleSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function removeAdvanceInvoiceSchedule(string $id, array $params = [], array $headers = []): RemoveAdvanceInvoiceScheduleSubscriptionResponse
     {
@@ -280,12 +277,10 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateForItemsSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function updateForItems(string $id, array $params, array $headers = []): UpdateForItemsSubscriptionResponse
     {
@@ -318,12 +313,10 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return RemoveCouponsSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function removeCoupons(string $id, array $params = [], array $headers = []): RemoveCouponsSubscriptionResponse
     {
@@ -367,12 +360,10 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return ResumeSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function resume(string $id, array $params = [], array $headers = []): ResumeSubscriptionResponse
     {
@@ -421,12 +412,10 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return CancelForItemsSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function cancelForItems(string $id, array $params = [], array $headers = []): CancelForItemsSubscriptionResponse
     {
@@ -460,12 +449,10 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return RegenerateInvoiceSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function regenerateInvoice(string $id, array $params = [], array $headers = []): RegenerateInvoiceSubscriptionResponse
     {
@@ -622,12 +609,10 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return ListSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListSubscriptionResponse
     {
@@ -847,12 +832,10 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateSubscriptionResponse
     {
@@ -888,12 +871,10 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return MoveSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function move(string $id, array $params, array $headers = []): MoveSubscriptionResponse
     {
@@ -925,12 +906,10 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return SubscriptionsForCustomerSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function subscriptionsForCustomer(string $id, array $params = [], array $headers = []): SubscriptionsForCustomerSubscriptionResponse
     {
@@ -1045,12 +1024,10 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateForCustomerSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createForCustomer(string $id, array $params, array $headers = []): CreateForCustomerSubscriptionResponse
     {
@@ -1184,12 +1161,10 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return ImportForItemsSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function importForItems(string $id, array $params, array $headers = []): ImportForItemsSubscriptionResponse
     {
@@ -1219,12 +1194,10 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveAdvanceInvoiceScheduleSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieveAdvanceInvoiceSchedule(string $id, array $headers = []): RetrieveAdvanceInvoiceScheduleSubscriptionResponse
     {
@@ -1258,12 +1231,10 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return RemoveScheduledCancellationSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function removeScheduledCancellation(string $id, array $params = [], array $headers = []): RemoveScheduledCancellationSubscriptionResponse
     {
@@ -1292,12 +1263,10 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveWithScheduledChangesSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieveWithScheduledChanges(string $id, array $headers = []): RetrieveWithScheduledChangesSubscriptionResponse
     {
@@ -1351,12 +1320,10 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return ReactivateSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function reactivate(string $id, array $params = [], array $headers = []): ReactivateSubscriptionResponse
     {
@@ -1400,12 +1367,10 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return ChargeFutureRenewalsSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function chargeFutureRenewals(string $id, array $params = [], array $headers = []): ChargeFutureRenewalsSubscriptionResponse
     {
@@ -1443,12 +1408,10 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return AddChargeAtTermEndSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function addChargeAtTermEnd(string $id, array $params, array $headers = []): AddChargeAtTermEndSubscriptionResponse
     {
@@ -1477,12 +1440,10 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return RemoveScheduledChangesSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function removeScheduledChanges(string $id, array $headers = []): RemoveScheduledChangesSubscriptionResponse
     {
@@ -1514,12 +1475,10 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return ChangeTermEndSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function changeTermEnd(string $id, array $params, array $headers = []): ChangeTermEndSubscriptionResponse
     {
@@ -1548,12 +1507,10 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteSubscriptionResponse
     {
@@ -1689,12 +1646,10 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateWithItemsSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createWithItems(string $id, array $params, array $headers = []): CreateWithItemsSubscriptionResponse
     {
@@ -1761,12 +1716,10 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return ImportUnbilledChargesSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function importUnbilledCharges(string $id, array $params, array $headers = []): ImportUnbilledChargesSubscriptionResponse
     {
@@ -1795,12 +1748,10 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return RemoveScheduledResumptionSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function removeScheduledResumption(string $id, array $headers = []): RemoveScheduledResumptionSubscriptionResponse
     {
@@ -1828,12 +1779,10 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveSubscriptionResponse
     {
@@ -2010,12 +1959,10 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdateSubscriptionResponse
     {
@@ -2062,12 +2009,10 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return ImportContractTermSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function importContractTerm(string $id, array $params = [], array $headers = []): ImportContractTermSubscriptionResponse
     {
@@ -2099,12 +2044,10 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return OverrideBillingProfileSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function overrideBillingProfile(string $id, array $params = [], array $headers = []): OverrideBillingProfileSubscriptionResponse
     {
@@ -2133,12 +2076,10 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return RemoveScheduledPauseSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function removeScheduledPause(string $id, array $headers = []): RemoveScheduledPauseSubscriptionResponse
     {
@@ -2180,12 +2121,10 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return EditAdvanceInvoiceScheduleSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function editAdvanceInvoiceSchedule(string $id, array $params = [], array $headers = []): EditAdvanceInvoiceScheduleSubscriptionResponse
     {
@@ -2217,12 +2156,10 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return ListDiscountsSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function listDiscounts(string $id, array $params = [], array $headers = []): ListDiscountsSubscriptionResponse
     {
@@ -2257,12 +2194,10 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return ContractTermsForSubscriptionSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function contractTermsForSubscription(string $id, array $params = [], array $headers = []): ContractTermsForSubscriptionSubscriptionResponse
     {
@@ -2297,12 +2232,10 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return PauseSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function pause(string $id, array $params = [], array $headers = []): PauseSubscriptionResponse
     {
@@ -2417,12 +2350,10 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return ImportForCustomerSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function importForCustomer(string $id, array $params, array $headers = []): ImportForCustomerSubscriptionResponse
     {
@@ -2602,12 +2533,10 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return ImportSubscriptionSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function importSubscription(array $params, array $headers = []): ImportSubscriptionSubscriptionResponse
     {
@@ -2655,12 +2584,10 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return CancelSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function cancel(string $id, array $params = [], array $headers = []): CancelSubscriptionResponse
     {
@@ -2697,12 +2624,10 @@ final class SubscriptionActions implements SubscriptionActionsInterface
     *   @param array<string, string> $headers
     *   @return ChargeAddonAtTermEndSubscriptionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function chargeAddonAtTermEnd(string $id, array $params, array $headers = []): ChargeAddonAtTermEndSubscriptionResponse
     {

--- a/src/Actions/SubscriptionEntitlementActions.php
+++ b/src/Actions/SubscriptionEntitlementActions.php
@@ -10,6 +10,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class SubscriptionEntitlementActions implements SubscriptionEntitlementActionsInterface
 {
@@ -31,6 +37,13 @@ final class SubscriptionEntitlementActions implements SubscriptionEntitlementAct
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return SetSubscriptionEntitlementAvailabilitySubscriptionEntitlementResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function setSubscriptionEntitlementAvailability(string $id, array $params, array $headers = []): SetSubscriptionEntitlementAvailabilitySubscriptionEntitlementResponse
     {
@@ -64,6 +77,13 @@ final class SubscriptionEntitlementActions implements SubscriptionEntitlementAct
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return SubscriptionEntitlementsForSubscriptionSubscriptionEntitlementResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function subscriptionEntitlementsForSubscription(string $id, array $params = [], array $headers = []): SubscriptionEntitlementsForSubscriptionSubscriptionEntitlementResponse
     {

--- a/src/Actions/SubscriptionEntitlementActions.php
+++ b/src/Actions/SubscriptionEntitlementActions.php
@@ -11,7 +11,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -38,12 +37,10 @@ final class SubscriptionEntitlementActions implements SubscriptionEntitlementAct
     *   @param array<string, string> $headers
     *   @return SetSubscriptionEntitlementAvailabilitySubscriptionEntitlementResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function setSubscriptionEntitlementAvailability(string $id, array $params, array $headers = []): SetSubscriptionEntitlementAvailabilitySubscriptionEntitlementResponse
     {
@@ -78,12 +75,10 @@ final class SubscriptionEntitlementActions implements SubscriptionEntitlementAct
     *   @param array<string, string> $headers
     *   @return SubscriptionEntitlementsForSubscriptionSubscriptionEntitlementResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function subscriptionEntitlementsForSubscription(string $id, array $params = [], array $headers = []): SubscriptionEntitlementsForSubscriptionSubscriptionEntitlementResponse
     {

--- a/src/Actions/TimeMachineActions.php
+++ b/src/Actions/TimeMachineActions.php
@@ -11,7 +11,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -33,12 +32,10 @@ final class TimeMachineActions implements TimeMachineActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveTimeMachineResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveTimeMachineResponse
     {
@@ -67,12 +64,10 @@ final class TimeMachineActions implements TimeMachineActionsInterface
     *   @param array<string, string> $headers
     *   @return TravelForwardTimeMachineResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function travelForward(string $id, array $params = [], array $headers = []): TravelForwardTimeMachineResponse
     {
@@ -103,12 +98,10 @@ final class TimeMachineActions implements TimeMachineActionsInterface
     *   @param array<string, string> $headers
     *   @return StartAfreshTimeMachineResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function startAfresh(string $id, array $params = [], array $headers = []): StartAfreshTimeMachineResponse
     {

--- a/src/Actions/TimeMachineActions.php
+++ b/src/Actions/TimeMachineActions.php
@@ -10,6 +10,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class TimeMachineActions implements TimeMachineActionsInterface
 {
@@ -26,6 +32,13 @@ final class TimeMachineActions implements TimeMachineActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveTimeMachineResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveTimeMachineResponse
     {
@@ -53,6 +66,13 @@ final class TimeMachineActions implements TimeMachineActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return TravelForwardTimeMachineResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function travelForward(string $id, array $params = [], array $headers = []): TravelForwardTimeMachineResponse
     {
@@ -82,6 +102,13 @@ final class TimeMachineActions implements TimeMachineActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return StartAfreshTimeMachineResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function startAfresh(string $id, array $params = [], array $headers = []): StartAfreshTimeMachineResponse
     {

--- a/src/Actions/TransactionActions.php
+++ b/src/Actions/TransactionActions.php
@@ -21,7 +21,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -154,12 +153,10 @@ final class TransactionActions implements TransactionActionsInterface
     *   @param array<string, string> $headers
     *   @return ListTransactionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListTransactionResponse
     {
@@ -191,12 +188,10 @@ final class TransactionActions implements TransactionActionsInterface
     *   @param array<string, string> $headers
     *   @return ReconcileTransactionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function reconcile(string $id, array $params = [], array $headers = []): ReconcileTransactionResponse
     {
@@ -225,12 +220,10 @@ final class TransactionActions implements TransactionActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveTransactionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveTransactionResponse
     {
@@ -260,12 +253,10 @@ final class TransactionActions implements TransactionActionsInterface
     *   @param array<string, string> $headers
     *   @return RefundTransactionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function refund(string $id, array $params = [], array $headers = []): RefundTransactionResponse
     {
@@ -297,12 +288,10 @@ final class TransactionActions implements TransactionActionsInterface
     *   @param array<string, string> $headers
     *   @return TransactionsForCustomerTransactionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function transactionsForCustomer(string $id, array $params = [], array $headers = []): TransactionsForCustomerTransactionResponse
     {
@@ -337,12 +326,10 @@ final class TransactionActions implements TransactionActionsInterface
     *   @param array<string, string> $headers
     *   @return RecordRefundTransactionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function recordRefund(string $id, array $params, array $headers = []): RecordRefundTransactionResponse
     {
@@ -374,12 +361,10 @@ final class TransactionActions implements TransactionActionsInterface
     *   @param array<string, string> $headers
     *   @return TransactionsForSubscriptionTransactionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function transactionsForSubscription(string $id, array $params = [], array $headers = []): TransactionsForSubscriptionTransactionResponse
     {
@@ -407,12 +392,10 @@ final class TransactionActions implements TransactionActionsInterface
     *   @param array<string, string> $headers
     *   @return VoidTransactionTransactionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function voidTransaction(string $id, array $headers = []): VoidTransactionTransactionResponse
     {
@@ -440,12 +423,10 @@ final class TransactionActions implements TransactionActionsInterface
     *   @param array<string, string> $headers
     *   @return SyncTransactionTransactionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function syncTransaction(string $id, array $headers = []): SyncTransactionTransactionResponse
     {
@@ -478,12 +459,10 @@ final class TransactionActions implements TransactionActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateAuthorizationTransactionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createAuthorization(array $params, array $headers = []): CreateAuthorizationTransactionResponse
     {
@@ -515,12 +494,10 @@ final class TransactionActions implements TransactionActionsInterface
     *   @param array<string, string> $headers
     *   @return PaymentsForInvoiceTransactionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function paymentsForInvoice(string $id, array $params = [], array $headers = []): PaymentsForInvoiceTransactionResponse
     {
@@ -550,12 +527,10 @@ final class TransactionActions implements TransactionActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteOfflineTransactionTransactionResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function deleteOfflineTransaction(string $id, array $params = [], array $headers = []): DeleteOfflineTransactionTransactionResponse
     {

--- a/src/Actions/TransactionActions.php
+++ b/src/Actions/TransactionActions.php
@@ -20,6 +20,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class TransactionActions implements TransactionActionsInterface
 {
@@ -147,6 +153,13 @@ final class TransactionActions implements TransactionActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListTransactionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListTransactionResponse
     {
@@ -177,6 +190,13 @@ final class TransactionActions implements TransactionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ReconcileTransactionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function reconcile(string $id, array $params = [], array $headers = []): ReconcileTransactionResponse
     {
@@ -204,6 +224,13 @@ final class TransactionActions implements TransactionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveTransactionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveTransactionResponse
     {
@@ -232,6 +259,13 @@ final class TransactionActions implements TransactionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RefundTransactionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function refund(string $id, array $params = [], array $headers = []): RefundTransactionResponse
     {
@@ -262,6 +296,13 @@ final class TransactionActions implements TransactionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return TransactionsForCustomerTransactionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function transactionsForCustomer(string $id, array $params = [], array $headers = []): TransactionsForCustomerTransactionResponse
     {
@@ -295,6 +336,13 @@ final class TransactionActions implements TransactionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RecordRefundTransactionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function recordRefund(string $id, array $params, array $headers = []): RecordRefundTransactionResponse
     {
@@ -325,6 +373,13 @@ final class TransactionActions implements TransactionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return TransactionsForSubscriptionTransactionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function transactionsForSubscription(string $id, array $params = [], array $headers = []): TransactionsForSubscriptionTransactionResponse
     {
@@ -351,6 +406,13 @@ final class TransactionActions implements TransactionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return VoidTransactionTransactionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function voidTransaction(string $id, array $headers = []): VoidTransactionTransactionResponse
     {
@@ -377,6 +439,13 @@ final class TransactionActions implements TransactionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return SyncTransactionTransactionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function syncTransaction(string $id, array $headers = []): SyncTransactionTransactionResponse
     {
@@ -408,6 +477,13 @@ final class TransactionActions implements TransactionActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateAuthorizationTransactionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createAuthorization(array $params, array $headers = []): CreateAuthorizationTransactionResponse
     {
@@ -438,6 +514,13 @@ final class TransactionActions implements TransactionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return PaymentsForInvoiceTransactionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function paymentsForInvoice(string $id, array $params = [], array $headers = []): PaymentsForInvoiceTransactionResponse
     {
@@ -466,6 +549,13 @@ final class TransactionActions implements TransactionActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteOfflineTransactionTransactionResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function deleteOfflineTransaction(string $id, array $params = [], array $headers = []): DeleteOfflineTransactionTransactionResponse
     {

--- a/src/Actions/UnbilledChargeActions.php
+++ b/src/Actions/UnbilledChargeActions.php
@@ -14,6 +14,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class UnbilledChargeActions implements UnbilledChargeActionsInterface
 {
@@ -30,6 +36,13 @@ final class UnbilledChargeActions implements UnbilledChargeActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteUnbilledChargeResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteUnbilledChargeResponse
     {
@@ -59,6 +72,13 @@ final class UnbilledChargeActions implements UnbilledChargeActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return InvoiceNowEstimateUnbilledChargeResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function invoiceNowEstimate(array $params = [], array $headers = []): InvoiceNowEstimateUnbilledChargeResponse
     {
@@ -89,6 +109,13 @@ final class UnbilledChargeActions implements UnbilledChargeActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return InvoiceUnbilledChargesUnbilledChargeResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function invoiceUnbilledCharges(array $params = [], array $headers = []): InvoiceUnbilledChargesUnbilledChargeResponse
     {
@@ -137,6 +164,13 @@ final class UnbilledChargeActions implements UnbilledChargeActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListUnbilledChargeResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListUnbilledChargeResponse
     {
@@ -206,6 +240,13 @@ final class UnbilledChargeActions implements UnbilledChargeActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateUnbilledChargeResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateUnbilledChargeResponse
     {
@@ -265,6 +306,13 @@ final class UnbilledChargeActions implements UnbilledChargeActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateUnbilledChargeUnbilledChargeResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createUnbilledCharge(array $params, array $headers = []): CreateUnbilledChargeUnbilledChargeResponse
     {

--- a/src/Actions/UnbilledChargeActions.php
+++ b/src/Actions/UnbilledChargeActions.php
@@ -15,7 +15,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -37,12 +36,10 @@ final class UnbilledChargeActions implements UnbilledChargeActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteUnbilledChargeResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteUnbilledChargeResponse
     {
@@ -73,12 +70,10 @@ final class UnbilledChargeActions implements UnbilledChargeActionsInterface
     *   @param array<string, string> $headers
     *   @return InvoiceNowEstimateUnbilledChargeResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function invoiceNowEstimate(array $params = [], array $headers = []): InvoiceNowEstimateUnbilledChargeResponse
     {
@@ -110,12 +105,10 @@ final class UnbilledChargeActions implements UnbilledChargeActionsInterface
     *   @param array<string, string> $headers
     *   @return InvoiceUnbilledChargesUnbilledChargeResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function invoiceUnbilledCharges(array $params = [], array $headers = []): InvoiceUnbilledChargesUnbilledChargeResponse
     {
@@ -165,12 +158,10 @@ final class UnbilledChargeActions implements UnbilledChargeActionsInterface
     *   @param array<string, string> $headers
     *   @return ListUnbilledChargeResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListUnbilledChargeResponse
     {
@@ -241,12 +232,10 @@ final class UnbilledChargeActions implements UnbilledChargeActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateUnbilledChargeResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateUnbilledChargeResponse
     {
@@ -307,12 +296,10 @@ final class UnbilledChargeActions implements UnbilledChargeActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateUnbilledChargeUnbilledChargeResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createUnbilledCharge(array $params, array $headers = []): CreateUnbilledChargeUnbilledChargeResponse
     {

--- a/src/Actions/UsageActions.php
+++ b/src/Actions/UsageActions.php
@@ -14,7 +14,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -41,12 +40,10 @@ final class UsageActions implements UsageActionsInterface
     *   @param array<string, string> $headers
     *   @return PdfUsageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function pdf(array $params, array $headers = []): PdfUsageResponse
     {
@@ -77,12 +74,10 @@ final class UsageActions implements UsageActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveUsageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $params, array $headers = []): RetrieveUsageResponse
     {
@@ -117,12 +112,10 @@ final class UsageActions implements UsageActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateUsageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(string $id, array $params, array $headers = []): CreateUsageResponse
     {
@@ -153,12 +146,10 @@ final class UsageActions implements UsageActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteUsageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $params, array $headers = []): DeleteUsageResponse
     {
@@ -233,12 +224,10 @@ final class UsageActions implements UsageActionsInterface
     *   @param array<string, string> $headers
     *   @return ListUsageResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListUsageResponse
     {

--- a/src/Actions/UsageActions.php
+++ b/src/Actions/UsageActions.php
@@ -13,6 +13,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class UsageActions implements UsageActionsInterface
 {
@@ -34,6 +40,13 @@ final class UsageActions implements UsageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return PdfUsageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function pdf(array $params, array $headers = []): PdfUsageResponse
     {
@@ -63,6 +76,13 @@ final class UsageActions implements UsageActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveUsageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $params, array $headers = []): RetrieveUsageResponse
     {
@@ -96,6 +116,13 @@ final class UsageActions implements UsageActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return CreateUsageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(string $id, array $params, array $headers = []): CreateUsageResponse
     {
@@ -125,6 +152,13 @@ final class UsageActions implements UsageActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteUsageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $params, array $headers = []): DeleteUsageResponse
     {
@@ -198,6 +232,13 @@ final class UsageActions implements UsageActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListUsageResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListUsageResponse
     {

--- a/src/Actions/UsageEventActions.php
+++ b/src/Actions/UsageEventActions.php
@@ -11,7 +11,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -38,12 +37,10 @@ final class UsageEventActions implements UsageEventActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateUsageEventResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateUsageEventResponse
     {
@@ -81,12 +78,10 @@ final class UsageEventActions implements UsageEventActionsInterface
     *   @param array<string, string> $headers
     *   @return BatchIngestUsageEventResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function batchIngest(array $params, array $headers = []): BatchIngestUsageEventResponse
     {

--- a/src/Actions/UsageEventActions.php
+++ b/src/Actions/UsageEventActions.php
@@ -10,6 +10,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class UsageEventActions implements UsageEventActionsInterface
 {
@@ -31,6 +37,13 @@ final class UsageEventActions implements UsageEventActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateUsageEventResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateUsageEventResponse
     {
@@ -67,6 +80,13 @@ final class UsageEventActions implements UsageEventActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return BatchIngestUsageEventResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function batchIngest(array $params, array $headers = []): BatchIngestUsageEventResponse
     {

--- a/src/Actions/UsageFileActions.php
+++ b/src/Actions/UsageFileActions.php
@@ -9,6 +9,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class UsageFileActions implements UsageFileActionsInterface
 {
@@ -25,6 +31,13 @@ final class UsageFileActions implements UsageFileActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return ProcessingStatusUsageFileResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function processingStatus(string $id, array $headers = []): ProcessingStatusUsageFileResponse
     {
@@ -53,6 +66,13 @@ final class UsageFileActions implements UsageFileActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return UploadUrlUsageFileResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function uploadUrl(array $params, array $headers = []): UploadUrlUsageFileResponse
     {

--- a/src/Actions/UsageFileActions.php
+++ b/src/Actions/UsageFileActions.php
@@ -10,7 +10,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -32,12 +31,10 @@ final class UsageFileActions implements UsageFileActionsInterface
     *   @param array<string, string> $headers
     *   @return ProcessingStatusUsageFileResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function processingStatus(string $id, array $headers = []): ProcessingStatusUsageFileResponse
     {
@@ -67,12 +64,10 @@ final class UsageFileActions implements UsageFileActionsInterface
     *   @param array<string, string> $headers
     *   @return UploadUrlUsageFileResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function uploadUrl(array $params, array $headers = []): UploadUrlUsageFileResponse
     {

--- a/src/Actions/VirtualBankAccountActions.php
+++ b/src/Actions/VirtualBankAccountActions.php
@@ -15,6 +15,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class VirtualBankAccountActions implements VirtualBankAccountActionsInterface
 {
@@ -31,6 +37,13 @@ final class VirtualBankAccountActions implements VirtualBankAccountActionsInterf
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteLocalVirtualBankAccountResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function deleteLocal(string $id, array $headers = []): DeleteLocalVirtualBankAccountResponse
     {
@@ -57,6 +70,13 @@ final class VirtualBankAccountActions implements VirtualBankAccountActionsInterf
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteVirtualBankAccountResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteVirtualBankAccountResponse
     {
@@ -105,6 +125,13 @@ final class VirtualBankAccountActions implements VirtualBankAccountActionsInterf
     *   
     *   @param array<string, string> $headers
     *   @return ListVirtualBankAccountResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListVirtualBankAccountResponse
     {
@@ -135,6 +162,13 @@ final class VirtualBankAccountActions implements VirtualBankAccountActionsInterf
     *   
     *   @param array<string, string> $headers
     *   @return CreateVirtualBankAccountResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateVirtualBankAccountResponse
     {
@@ -162,6 +196,13 @@ final class VirtualBankAccountActions implements VirtualBankAccountActionsInterf
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return SyncFundVirtualBankAccountResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function syncFund(string $id, array $headers = []): SyncFundVirtualBankAccountResponse
     {
@@ -188,6 +229,13 @@ final class VirtualBankAccountActions implements VirtualBankAccountActionsInterf
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveVirtualBankAccountResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveVirtualBankAccountResponse
     {
@@ -217,6 +265,13 @@ final class VirtualBankAccountActions implements VirtualBankAccountActionsInterf
     *   
     *   @param array<string, string> $headers
     *   @return CreateUsingPermanentTokenVirtualBankAccountResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function createUsingPermanentToken(array $params, array $headers = []): CreateUsingPermanentTokenVirtualBankAccountResponse
     {

--- a/src/Actions/VirtualBankAccountActions.php
+++ b/src/Actions/VirtualBankAccountActions.php
@@ -16,7 +16,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -38,12 +37,10 @@ final class VirtualBankAccountActions implements VirtualBankAccountActionsInterf
     *   @param array<string, string> $headers
     *   @return DeleteLocalVirtualBankAccountResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function deleteLocal(string $id, array $headers = []): DeleteLocalVirtualBankAccountResponse
     {
@@ -71,12 +68,10 @@ final class VirtualBankAccountActions implements VirtualBankAccountActionsInterf
     *   @param array<string, string> $headers
     *   @return DeleteVirtualBankAccountResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteVirtualBankAccountResponse
     {
@@ -126,12 +121,10 @@ final class VirtualBankAccountActions implements VirtualBankAccountActionsInterf
     *   @param array<string, string> $headers
     *   @return ListVirtualBankAccountResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListVirtualBankAccountResponse
     {
@@ -163,12 +156,10 @@ final class VirtualBankAccountActions implements VirtualBankAccountActionsInterf
     *   @param array<string, string> $headers
     *   @return CreateVirtualBankAccountResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateVirtualBankAccountResponse
     {
@@ -197,12 +188,10 @@ final class VirtualBankAccountActions implements VirtualBankAccountActionsInterf
     *   @param array<string, string> $headers
     *   @return SyncFundVirtualBankAccountResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function syncFund(string $id, array $headers = []): SyncFundVirtualBankAccountResponse
     {
@@ -230,12 +219,10 @@ final class VirtualBankAccountActions implements VirtualBankAccountActionsInterf
     *   @param array<string, string> $headers
     *   @return RetrieveVirtualBankAccountResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveVirtualBankAccountResponse
     {
@@ -266,12 +253,10 @@ final class VirtualBankAccountActions implements VirtualBankAccountActionsInterf
     *   @param array<string, string> $headers
     *   @return CreateUsingPermanentTokenVirtualBankAccountResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function createUsingPermanentToken(array $params, array $headers = []): CreateUsingPermanentTokenVirtualBankAccountResponse
     {

--- a/src/Actions/WebhookEndpointActions.php
+++ b/src/Actions/WebhookEndpointActions.php
@@ -13,6 +13,12 @@ use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Chargebee\Exceptions\PaymentException;
+use Chargebee\Exceptions\OperationFailedException;
+use Chargebee\Exceptions\APIError;
+use Chargebee\Exceptions\InvalidRequestException;
 
 final class WebhookEndpointActions implements WebhookEndpointActionsInterface
 {
@@ -29,6 +35,13 @@ final class WebhookEndpointActions implements WebhookEndpointActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return DeleteWebhookEndpointResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteWebhookEndpointResponse
     {
@@ -55,6 +68,13 @@ final class WebhookEndpointActions implements WebhookEndpointActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return RetrieveWebhookEndpointResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveWebhookEndpointResponse
     {
@@ -90,6 +110,13 @@ final class WebhookEndpointActions implements WebhookEndpointActionsInterface
     *   @param string $id  
     *   @param array<string, string> $headers
     *   @return UpdateWebhookEndpointResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdateWebhookEndpointResponse
     {
@@ -120,6 +147,13 @@ final class WebhookEndpointActions implements WebhookEndpointActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return ListWebhookEndpointResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListWebhookEndpointResponse
     {
@@ -157,6 +191,13 @@ final class WebhookEndpointActions implements WebhookEndpointActionsInterface
     *   
     *   @param array<string, string> $headers
     *   @return CreateWebhookEndpointResponse
+    *   @throws PaymentException
+    *   @throws ClientExceptionInterface
+    *   @throws OperationFailedException
+    *   @throws APIError
+    *   @throws InvalidRequestException
+    *   @throws Exception
+    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateWebhookEndpointResponse
     {

--- a/src/Actions/WebhookEndpointActions.php
+++ b/src/Actions/WebhookEndpointActions.php
@@ -14,7 +14,6 @@ use Chargebee\ValueObjects\APIRequester;
 use Chargebee\HttpClient\HttpClientFactory;
 use Chargebee\Environment;
 use Exception;
-use Psr\Http\Client\ClientExceptionInterface;
 use Chargebee\Exceptions\PaymentException;
 use Chargebee\Exceptions\OperationFailedException;
 use Chargebee\Exceptions\APIError;
@@ -36,12 +35,10 @@ final class WebhookEndpointActions implements WebhookEndpointActionsInterface
     *   @param array<string, string> $headers
     *   @return DeleteWebhookEndpointResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function delete(string $id, array $headers = []): DeleteWebhookEndpointResponse
     {
@@ -69,12 +66,10 @@ final class WebhookEndpointActions implements WebhookEndpointActionsInterface
     *   @param array<string, string> $headers
     *   @return RetrieveWebhookEndpointResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function retrieve(string $id, array $headers = []): RetrieveWebhookEndpointResponse
     {
@@ -111,12 +106,10 @@ final class WebhookEndpointActions implements WebhookEndpointActionsInterface
     *   @param array<string, string> $headers
     *   @return UpdateWebhookEndpointResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function update(string $id, array $params = [], array $headers = []): UpdateWebhookEndpointResponse
     {
@@ -148,12 +141,10 @@ final class WebhookEndpointActions implements WebhookEndpointActionsInterface
     *   @param array<string, string> $headers
     *   @return ListWebhookEndpointResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function all(array $params = [], array $headers = []): ListWebhookEndpointResponse
     {
@@ -192,12 +183,10 @@ final class WebhookEndpointActions implements WebhookEndpointActionsInterface
     *   @param array<string, string> $headers
     *   @return CreateWebhookEndpointResponse
     *   @throws PaymentException
-    *   @throws ClientExceptionInterface
     *   @throws OperationFailedException
     *   @throws APIError
     *   @throws InvalidRequestException
     *   @throws Exception
-    *   @throws ClientExceptionInterface
     */
     public function create(array $params, array $headers = []): CreateWebhookEndpointResponse
     {

--- a/src/Responses/AddonResponse/ListAddonResponse.php
+++ b/src/Responses/AddonResponse/ListAddonResponse.php
@@ -51,18 +51,4 @@ class ListAddonResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ListAddonResponseListObject {
-    
-        public Addon $addon;
-    
-public function __construct(
-    Addon $addon,
-){ 
-    $this->addon = $addon;
-
-}
-}
-
 ?>

--- a/src/Responses/AddonResponse/ListAddonResponseListObject.php
+++ b/src/Responses/AddonResponse/ListAddonResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\AddonResponse;
+
+use Chargebee\Resources\Addon\Addon;
+
+class ListAddonResponseListObject
+{ 
+    public Addon $addon;
+    public function __construct(
+        Addon $addon,
+    ) { 
+        $this->addon = $addon;
+    }
+}

--- a/src/Responses/AttachedItemResponse/ListAttachedItemResponse.php
+++ b/src/Responses/AttachedItemResponse/ListAttachedItemResponse.php
@@ -51,18 +51,4 @@ class ListAttachedItemResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ListAttachedItemResponseListObject {
-    
-        public AttachedItem $attached_item;
-    
-public function __construct(
-    AttachedItem $attached_item,
-){ 
-    $this->attached_item = $attached_item;
-
-}
-}
-
 ?>

--- a/src/Responses/AttachedItemResponse/ListAttachedItemResponseListObject.php
+++ b/src/Responses/AttachedItemResponse/ListAttachedItemResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\AttachedItemResponse;
+
+use Chargebee\Resources\AttachedItem\AttachedItem;
+
+class ListAttachedItemResponseListObject
+{ 
+    public AttachedItem $attached_item;
+    public function __construct(
+        AttachedItem $attached_item,
+    ) { 
+        $this->attached_item = $attached_item;
+    }
+}

--- a/src/Responses/BusinessEntityResponse/GetTransfersBusinessEntityResponse.php
+++ b/src/Responses/BusinessEntityResponse/GetTransfersBusinessEntityResponse.php
@@ -51,18 +51,4 @@ class GetTransfersBusinessEntityResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class GetTransfersBusinessEntityResponseListObject {
-    
-        public BusinessEntityTransfer $business_entity_transfer;
-    
-public function __construct(
-    BusinessEntityTransfer $business_entity_transfer,
-){ 
-    $this->business_entity_transfer = $business_entity_transfer;
-
-}
-}
-
 ?>

--- a/src/Responses/BusinessEntityResponse/GetTransfersBusinessEntityResponseListObject.php
+++ b/src/Responses/BusinessEntityResponse/GetTransfersBusinessEntityResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\BusinessEntityResponse;
+
+use Chargebee\Resources\BusinessEntityTransfer\BusinessEntityTransfer;
+
+class GetTransfersBusinessEntityResponseListObject
+{ 
+    public BusinessEntityTransfer $business_entity_transfer;
+    public function __construct(
+        BusinessEntityTransfer $business_entity_transfer,
+    ) { 
+        $this->business_entity_transfer = $business_entity_transfer;
+    }
+}

--- a/src/Responses/CommentResponse/ListCommentResponse.php
+++ b/src/Responses/CommentResponse/ListCommentResponse.php
@@ -51,18 +51,4 @@ class ListCommentResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ListCommentResponseListObject {
-    
-        public Comment $comment;
-    
-public function __construct(
-    Comment $comment,
-){ 
-    $this->comment = $comment;
-
-}
-}
-
 ?>

--- a/src/Responses/CommentResponse/ListCommentResponseListObject.php
+++ b/src/Responses/CommentResponse/ListCommentResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\CommentResponse;
+
+use Chargebee\Resources\Comment\Comment;
+
+class ListCommentResponseListObject
+{ 
+    public Comment $comment;
+    public function __construct(
+        Comment $comment,
+    ) { 
+        $this->comment = $comment;
+    }
+}

--- a/src/Responses/CouponCodeResponse/ListCouponCodeResponse.php
+++ b/src/Responses/CouponCodeResponse/ListCouponCodeResponse.php
@@ -51,18 +51,4 @@ class ListCouponCodeResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ListCouponCodeResponseListObject {
-    
-        public CouponCode $coupon_code;
-    
-public function __construct(
-    CouponCode $coupon_code,
-){ 
-    $this->coupon_code = $coupon_code;
-
-}
-}
-
 ?>

--- a/src/Responses/CouponCodeResponse/ListCouponCodeResponseListObject.php
+++ b/src/Responses/CouponCodeResponse/ListCouponCodeResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\CouponCodeResponse;
+
+use Chargebee\Resources\CouponCode\CouponCode;
+
+class ListCouponCodeResponseListObject
+{ 
+    public CouponCode $coupon_code;
+    public function __construct(
+        CouponCode $coupon_code,
+    ) { 
+        $this->coupon_code = $coupon_code;
+    }
+}

--- a/src/Responses/CouponResponse/ListCouponResponse.php
+++ b/src/Responses/CouponResponse/ListCouponResponse.php
@@ -51,18 +51,4 @@ class ListCouponResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ListCouponResponseListObject {
-    
-        public Coupon $coupon;
-    
-public function __construct(
-    Coupon $coupon,
-){ 
-    $this->coupon = $coupon;
-
-}
-}
-
 ?>

--- a/src/Responses/CouponResponse/ListCouponResponseListObject.php
+++ b/src/Responses/CouponResponse/ListCouponResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\CouponResponse;
+
+use Chargebee\Resources\Coupon\Coupon;
+
+class ListCouponResponseListObject
+{ 
+    public Coupon $coupon;
+    public function __construct(
+        Coupon $coupon,
+    ) { 
+        $this->coupon = $coupon;
+    }
+}

--- a/src/Responses/CouponSetResponse/ListCouponSetResponse.php
+++ b/src/Responses/CouponSetResponse/ListCouponSetResponse.php
@@ -51,18 +51,4 @@ class ListCouponSetResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ListCouponSetResponseListObject {
-    
-        public CouponSet $coupon_set;
-    
-public function __construct(
-    CouponSet $coupon_set,
-){ 
-    $this->coupon_set = $coupon_set;
-
-}
-}
-
 ?>

--- a/src/Responses/CouponSetResponse/ListCouponSetResponseListObject.php
+++ b/src/Responses/CouponSetResponse/ListCouponSetResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\CouponSetResponse;
+
+use Chargebee\Resources\CouponSet\CouponSet;
+
+class ListCouponSetResponseListObject
+{ 
+    public CouponSet $coupon_set;
+    public function __construct(
+        CouponSet $coupon_set,
+    ) { 
+        $this->coupon_set = $coupon_set;
+    }
+}

--- a/src/Responses/CreditNoteResponse/CreditNotesForCustomerCreditNoteResponse.php
+++ b/src/Responses/CreditNoteResponse/CreditNotesForCustomerCreditNoteResponse.php
@@ -51,18 +51,4 @@ class CreditNotesForCustomerCreditNoteResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class CreditNotesForCustomerCreditNoteResponseListObject {
-    
-        public CreditNote $credit_note;
-    
-public function __construct(
-    CreditNote $credit_note,
-){ 
-    $this->credit_note = $credit_note;
-
-}
-}
-
 ?>

--- a/src/Responses/CreditNoteResponse/CreditNotesForCustomerCreditNoteResponseListObject.php
+++ b/src/Responses/CreditNoteResponse/CreditNotesForCustomerCreditNoteResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\CreditNoteResponse;
+
+use Chargebee\Resources\CreditNote\CreditNote;
+
+class CreditNotesForCustomerCreditNoteResponseListObject
+{ 
+    public CreditNote $credit_note;
+    public function __construct(
+        CreditNote $credit_note,
+    ) { 
+        $this->credit_note = $credit_note;
+    }
+}

--- a/src/Responses/CreditNoteResponse/ListCreditNoteResponse.php
+++ b/src/Responses/CreditNoteResponse/ListCreditNoteResponse.php
@@ -51,18 +51,4 @@ class ListCreditNoteResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ListCreditNoteResponseListObject {
-    
-        public CreditNote $credit_note;
-    
-public function __construct(
-    CreditNote $credit_note,
-){ 
-    $this->credit_note = $credit_note;
-
-}
-}
-
 ?>

--- a/src/Responses/CreditNoteResponse/ListCreditNoteResponseListObject.php
+++ b/src/Responses/CreditNoteResponse/ListCreditNoteResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\CreditNoteResponse;
+
+use Chargebee\Resources\CreditNote\CreditNote;
+
+class ListCreditNoteResponseListObject
+{ 
+    public CreditNote $credit_note;
+    public function __construct(
+        CreditNote $credit_note,
+    ) { 
+        $this->credit_note = $credit_note;
+    }
+}

--- a/src/Responses/CustomerEntitlementResponse/EntitlementsForCustomerCustomerEntitlementResponse.php
+++ b/src/Responses/CustomerEntitlementResponse/EntitlementsForCustomerCustomerEntitlementResponse.php
@@ -51,18 +51,4 @@ class EntitlementsForCustomerCustomerEntitlementResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class EntitlementsForCustomerCustomerEntitlementResponseListObject {
-    
-        public CustomerEntitlement $customer_entitlement;
-    
-public function __construct(
-    CustomerEntitlement $customer_entitlement,
-){ 
-    $this->customer_entitlement = $customer_entitlement;
-
-}
-}
-
 ?>

--- a/src/Responses/CustomerEntitlementResponse/EntitlementsForCustomerCustomerEntitlementResponseListObject.php
+++ b/src/Responses/CustomerEntitlementResponse/EntitlementsForCustomerCustomerEntitlementResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\CustomerEntitlementResponse;
+
+use Chargebee\Resources\CustomerEntitlement\CustomerEntitlement;
+
+class EntitlementsForCustomerCustomerEntitlementResponseListObject
+{ 
+    public CustomerEntitlement $customer_entitlement;
+    public function __construct(
+        CustomerEntitlement $customer_entitlement,
+    ) { 
+        $this->customer_entitlement = $customer_entitlement;
+    }
+}

--- a/src/Responses/CustomerResponse/ContactsForCustomerCustomerResponse.php
+++ b/src/Responses/CustomerResponse/ContactsForCustomerCustomerResponse.php
@@ -51,18 +51,4 @@ class ContactsForCustomerCustomerResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ContactsForCustomerCustomerResponseListObject {
-    
-        public Contact $contact;
-    
-public function __construct(
-    Contact $contact,
-){ 
-    $this->contact = $contact;
-
-}
-}
-
 ?>

--- a/src/Responses/CustomerResponse/ContactsForCustomerCustomerResponseListObject.php
+++ b/src/Responses/CustomerResponse/ContactsForCustomerCustomerResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\CustomerResponse;
+
+use Chargebee\Resources\Contact\Contact;
+
+class ContactsForCustomerCustomerResponseListObject
+{ 
+    public Contact $contact;
+    public function __construct(
+        Contact $contact,
+    ) { 
+        $this->contact = $contact;
+    }
+}

--- a/src/Responses/CustomerResponse/ListCustomerResponse.php
+++ b/src/Responses/CustomerResponse/ListCustomerResponse.php
@@ -54,24 +54,4 @@ class ListCustomerResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ListCustomerResponseListObject {
-    
-        public Customer $customer;
-    
-        public ?Card $card;
-    
-public function __construct(
-    Customer $customer,
-
-    ?Card $card,
-){ 
-    $this->customer = $customer;
-
-    $this->card = $card;
-
-}
-}
-
 ?>

--- a/src/Responses/CustomerResponse/ListCustomerResponseListObject.php
+++ b/src/Responses/CustomerResponse/ListCustomerResponseListObject.php
@@ -1,0 +1,20 @@
+<?php
+namespace Chargebee\Responses\CustomerResponse;
+
+use Chargebee\Resources\Customer\Customer;
+use Chargebee\Resources\Card\Card;
+
+class ListCustomerResponseListObject
+{ 
+    public Customer $customer;
+
+    public ?Card $card;
+    public function __construct(
+        Customer $customer,
+    
+        ?Card $card,
+    ) { 
+        $this->customer = $customer;
+        $this->card = $card;
+    }
+}

--- a/src/Responses/CustomerResponse/ListHierarchyDetailCustomerResponse.php
+++ b/src/Responses/CustomerResponse/ListHierarchyDetailCustomerResponse.php
@@ -51,18 +51,4 @@ class ListHierarchyDetailCustomerResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ListHierarchyDetailCustomerResponseListObject {
-    
-        public Hierarchy $hierarchies;
-    
-public function __construct(
-    Hierarchy $hierarchies,
-){ 
-    $this->hierarchies = $hierarchies;
-
-}
-}
-
 ?>

--- a/src/Responses/CustomerResponse/ListHierarchyDetailCustomerResponseListObject.php
+++ b/src/Responses/CustomerResponse/ListHierarchyDetailCustomerResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\CustomerResponse;
+
+use Chargebee\Resources\Hierarchy\Hierarchy;
+
+class ListHierarchyDetailCustomerResponseListObject
+{ 
+    public Hierarchy $hierarchies;
+    public function __construct(
+        Hierarchy $hierarchies,
+    ) { 
+        $this->hierarchies = $hierarchies;
+    }
+}

--- a/src/Responses/DifferentialPriceResponse/ListDifferentialPriceResponse.php
+++ b/src/Responses/DifferentialPriceResponse/ListDifferentialPriceResponse.php
@@ -51,18 +51,4 @@ class ListDifferentialPriceResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ListDifferentialPriceResponseListObject {
-    
-        public DifferentialPrice $differential_price;
-    
-public function __construct(
-    DifferentialPrice $differential_price,
-){ 
-    $this->differential_price = $differential_price;
-
-}
-}
-
 ?>

--- a/src/Responses/DifferentialPriceResponse/ListDifferentialPriceResponseListObject.php
+++ b/src/Responses/DifferentialPriceResponse/ListDifferentialPriceResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\DifferentialPriceResponse;
+
+use Chargebee\Resources\DifferentialPrice\DifferentialPrice;
+
+class ListDifferentialPriceResponseListObject
+{ 
+    public DifferentialPrice $differential_price;
+    public function __construct(
+        DifferentialPrice $differential_price,
+    ) { 
+        $this->differential_price = $differential_price;
+    }
+}

--- a/src/Responses/EntitlementOverrideResponse/ListEntitlementOverrideForSubscriptionEntitlementOverrideResponse.php
+++ b/src/Responses/EntitlementOverrideResponse/ListEntitlementOverrideForSubscriptionEntitlementOverrideResponse.php
@@ -51,18 +51,4 @@ class ListEntitlementOverrideForSubscriptionEntitlementOverrideResponse extends 
         return $data;
     }
 }
-
-
-class ListEntitlementOverrideForSubscriptionEntitlementOverrideResponseListObject {
-    
-        public EntitlementOverride $entitlement_override;
-    
-public function __construct(
-    EntitlementOverride $entitlement_override,
-){ 
-    $this->entitlement_override = $entitlement_override;
-
-}
-}
-
 ?>

--- a/src/Responses/EntitlementOverrideResponse/ListEntitlementOverrideForSubscriptionEntitlementOverrideResponseListObject.php
+++ b/src/Responses/EntitlementOverrideResponse/ListEntitlementOverrideForSubscriptionEntitlementOverrideResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\EntitlementOverrideResponse;
+
+use Chargebee\Resources\EntitlementOverride\EntitlementOverride;
+
+class ListEntitlementOverrideForSubscriptionEntitlementOverrideResponseListObject
+{ 
+    public EntitlementOverride $entitlement_override;
+    public function __construct(
+        EntitlementOverride $entitlement_override,
+    ) { 
+        $this->entitlement_override = $entitlement_override;
+    }
+}

--- a/src/Responses/EntitlementResponse/ListEntitlementResponse.php
+++ b/src/Responses/EntitlementResponse/ListEntitlementResponse.php
@@ -51,18 +51,4 @@ class ListEntitlementResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ListEntitlementResponseListObject {
-    
-        public Entitlement $entitlement;
-    
-public function __construct(
-    Entitlement $entitlement,
-){ 
-    $this->entitlement = $entitlement;
-
-}
-}
-
 ?>

--- a/src/Responses/EntitlementResponse/ListEntitlementResponseListObject.php
+++ b/src/Responses/EntitlementResponse/ListEntitlementResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\EntitlementResponse;
+
+use Chargebee\Resources\Entitlement\Entitlement;
+
+class ListEntitlementResponseListObject
+{ 
+    public Entitlement $entitlement;
+    public function __construct(
+        Entitlement $entitlement,
+    ) { 
+        $this->entitlement = $entitlement;
+    }
+}

--- a/src/Responses/EventResponse/ListEventResponse.php
+++ b/src/Responses/EventResponse/ListEventResponse.php
@@ -51,18 +51,4 @@ class ListEventResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ListEventResponseListObject {
-    
-        public Event $event;
-    
-public function __construct(
-    Event $event,
-){ 
-    $this->event = $event;
-
-}
-}
-
 ?>

--- a/src/Responses/EventResponse/ListEventResponseListObject.php
+++ b/src/Responses/EventResponse/ListEventResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\EventResponse;
+
+use Chargebee\Resources\Event\Event;
+
+class ListEventResponseListObject
+{ 
+    public Event $event;
+    public function __construct(
+        Event $event,
+    ) { 
+        $this->event = $event;
+    }
+}

--- a/src/Responses/FeatureResponse/ListFeatureResponse.php
+++ b/src/Responses/FeatureResponse/ListFeatureResponse.php
@@ -51,18 +51,4 @@ class ListFeatureResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ListFeatureResponseListObject {
-    
-        public Feature $feature;
-    
-public function __construct(
-    Feature $feature,
-){ 
-    $this->feature = $feature;
-
-}
-}
-
 ?>

--- a/src/Responses/FeatureResponse/ListFeatureResponseListObject.php
+++ b/src/Responses/FeatureResponse/ListFeatureResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\FeatureResponse;
+
+use Chargebee\Resources\Feature\Feature;
+
+class ListFeatureResponseListObject
+{ 
+    public Feature $feature;
+    public function __construct(
+        Feature $feature,
+    ) { 
+        $this->feature = $feature;
+    }
+}

--- a/src/Responses/GiftResponse/ListGiftResponse.php
+++ b/src/Responses/GiftResponse/ListGiftResponse.php
@@ -54,24 +54,4 @@ class ListGiftResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ListGiftResponseListObject {
-    
-        public Gift $gift;
-    
-        public Subscription $subscription;
-    
-public function __construct(
-    Gift $gift,
-
-    Subscription $subscription,
-){ 
-    $this->gift = $gift;
-
-    $this->subscription = $subscription;
-
-}
-}
-
 ?>

--- a/src/Responses/GiftResponse/ListGiftResponseListObject.php
+++ b/src/Responses/GiftResponse/ListGiftResponseListObject.php
@@ -1,0 +1,20 @@
+<?php
+namespace Chargebee\Responses\GiftResponse;
+
+use Chargebee\Resources\Gift\Gift;
+use Chargebee\Resources\Subscription\Subscription;
+
+class ListGiftResponseListObject
+{ 
+    public Gift $gift;
+
+    public Subscription $subscription;
+    public function __construct(
+        Gift $gift,
+    
+        Subscription $subscription,
+    ) { 
+        $this->gift = $gift;
+        $this->subscription = $subscription;
+    }
+}

--- a/src/Responses/HostedPageResponse/ListHostedPageResponse.php
+++ b/src/Responses/HostedPageResponse/ListHostedPageResponse.php
@@ -51,18 +51,4 @@ class ListHostedPageResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ListHostedPageResponseListObject {
-    
-        public HostedPage $hosted_page;
-    
-public function __construct(
-    HostedPage $hosted_page,
-){ 
-    $this->hosted_page = $hosted_page;
-
-}
-}
-
 ?>

--- a/src/Responses/HostedPageResponse/ListHostedPageResponseListObject.php
+++ b/src/Responses/HostedPageResponse/ListHostedPageResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\HostedPageResponse;
+
+use Chargebee\Resources\HostedPage\HostedPage;
+
+class ListHostedPageResponseListObject
+{ 
+    public HostedPage $hosted_page;
+    public function __construct(
+        HostedPage $hosted_page,
+    ) { 
+        $this->hosted_page = $hosted_page;
+    }
+}

--- a/src/Responses/InvoiceResponse/InvoicesForCustomerInvoiceResponse.php
+++ b/src/Responses/InvoiceResponse/InvoicesForCustomerInvoiceResponse.php
@@ -51,18 +51,4 @@ class InvoicesForCustomerInvoiceResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class InvoicesForCustomerInvoiceResponseListObject {
-    
-        public Invoice $invoice;
-    
-public function __construct(
-    Invoice $invoice,
-){ 
-    $this->invoice = $invoice;
-
-}
-}
-
 ?>

--- a/src/Responses/InvoiceResponse/InvoicesForCustomerInvoiceResponseListObject.php
+++ b/src/Responses/InvoiceResponse/InvoicesForCustomerInvoiceResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\InvoiceResponse;
+
+use Chargebee\Resources\Invoice\Invoice;
+
+class InvoicesForCustomerInvoiceResponseListObject
+{ 
+    public Invoice $invoice;
+    public function __construct(
+        Invoice $invoice,
+    ) { 
+        $this->invoice = $invoice;
+    }
+}

--- a/src/Responses/InvoiceResponse/InvoicesForSubscriptionInvoiceResponse.php
+++ b/src/Responses/InvoiceResponse/InvoicesForSubscriptionInvoiceResponse.php
@@ -51,18 +51,4 @@ class InvoicesForSubscriptionInvoiceResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class InvoicesForSubscriptionInvoiceResponseListObject {
-    
-        public Invoice $invoice;
-    
-public function __construct(
-    Invoice $invoice,
-){ 
-    $this->invoice = $invoice;
-
-}
-}
-
 ?>

--- a/src/Responses/InvoiceResponse/InvoicesForSubscriptionInvoiceResponseListObject.php
+++ b/src/Responses/InvoiceResponse/InvoicesForSubscriptionInvoiceResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\InvoiceResponse;
+
+use Chargebee\Resources\Invoice\Invoice;
+
+class InvoicesForSubscriptionInvoiceResponseListObject
+{ 
+    public Invoice $invoice;
+    public function __construct(
+        Invoice $invoice,
+    ) { 
+        $this->invoice = $invoice;
+    }
+}

--- a/src/Responses/InvoiceResponse/ListInvoiceResponse.php
+++ b/src/Responses/InvoiceResponse/ListInvoiceResponse.php
@@ -51,18 +51,4 @@ class ListInvoiceResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ListInvoiceResponseListObject {
-    
-        public Invoice $invoice;
-    
-public function __construct(
-    Invoice $invoice,
-){ 
-    $this->invoice = $invoice;
-
-}
-}
-
 ?>

--- a/src/Responses/InvoiceResponse/ListInvoiceResponseListObject.php
+++ b/src/Responses/InvoiceResponse/ListInvoiceResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\InvoiceResponse;
+
+use Chargebee\Resources\Invoice\Invoice;
+
+class ListInvoiceResponseListObject
+{ 
+    public Invoice $invoice;
+    public function __construct(
+        Invoice $invoice,
+    ) { 
+        $this->invoice = $invoice;
+    }
+}

--- a/src/Responses/InvoiceResponse/ListPaymentReferenceNumbersInvoiceResponse.php
+++ b/src/Responses/InvoiceResponse/ListPaymentReferenceNumbersInvoiceResponse.php
@@ -51,18 +51,4 @@ class ListPaymentReferenceNumbersInvoiceResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ListPaymentReferenceNumbersInvoiceResponseListObject {
-    
-        public PaymentReferenceNumber $payment_reference_number;
-    
-public function __construct(
-    PaymentReferenceNumber $payment_reference_number,
-){ 
-    $this->payment_reference_number = $payment_reference_number;
-
-}
-}
-
 ?>

--- a/src/Responses/InvoiceResponse/ListPaymentReferenceNumbersInvoiceResponseListObject.php
+++ b/src/Responses/InvoiceResponse/ListPaymentReferenceNumbersInvoiceResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\InvoiceResponse;
+
+use Chargebee\Resources\PaymentReferenceNumber\PaymentReferenceNumber;
+
+class ListPaymentReferenceNumbersInvoiceResponseListObject
+{ 
+    public PaymentReferenceNumber $payment_reference_number;
+    public function __construct(
+        PaymentReferenceNumber $payment_reference_number,
+    ) { 
+        $this->payment_reference_number = $payment_reference_number;
+    }
+}

--- a/src/Responses/ItemEntitlementResponse/ItemEntitlementsForFeatureItemEntitlementResponse.php
+++ b/src/Responses/ItemEntitlementResponse/ItemEntitlementsForFeatureItemEntitlementResponse.php
@@ -51,18 +51,4 @@ class ItemEntitlementsForFeatureItemEntitlementResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ItemEntitlementsForFeatureItemEntitlementResponseListObject {
-    
-        public ItemEntitlement $item_entitlement;
-    
-public function __construct(
-    ItemEntitlement $item_entitlement,
-){ 
-    $this->item_entitlement = $item_entitlement;
-
-}
-}
-
 ?>

--- a/src/Responses/ItemEntitlementResponse/ItemEntitlementsForFeatureItemEntitlementResponseListObject.php
+++ b/src/Responses/ItemEntitlementResponse/ItemEntitlementsForFeatureItemEntitlementResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\ItemEntitlementResponse;
+
+use Chargebee\Resources\ItemEntitlement\ItemEntitlement;
+
+class ItemEntitlementsForFeatureItemEntitlementResponseListObject
+{ 
+    public ItemEntitlement $item_entitlement;
+    public function __construct(
+        ItemEntitlement $item_entitlement,
+    ) { 
+        $this->item_entitlement = $item_entitlement;
+    }
+}

--- a/src/Responses/ItemEntitlementResponse/ItemEntitlementsForItemItemEntitlementResponse.php
+++ b/src/Responses/ItemEntitlementResponse/ItemEntitlementsForItemItemEntitlementResponse.php
@@ -51,18 +51,4 @@ class ItemEntitlementsForItemItemEntitlementResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ItemEntitlementsForItemItemEntitlementResponseListObject {
-    
-        public ItemEntitlement $item_entitlement;
-    
-public function __construct(
-    ItemEntitlement $item_entitlement,
-){ 
-    $this->item_entitlement = $item_entitlement;
-
-}
-}
-
 ?>

--- a/src/Responses/ItemEntitlementResponse/ItemEntitlementsForItemItemEntitlementResponseListObject.php
+++ b/src/Responses/ItemEntitlementResponse/ItemEntitlementsForItemItemEntitlementResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\ItemEntitlementResponse;
+
+use Chargebee\Resources\ItemEntitlement\ItemEntitlement;
+
+class ItemEntitlementsForItemItemEntitlementResponseListObject
+{ 
+    public ItemEntitlement $item_entitlement;
+    public function __construct(
+        ItemEntitlement $item_entitlement,
+    ) { 
+        $this->item_entitlement = $item_entitlement;
+    }
+}

--- a/src/Responses/ItemFamilyResponse/ListItemFamilyResponse.php
+++ b/src/Responses/ItemFamilyResponse/ListItemFamilyResponse.php
@@ -51,18 +51,4 @@ class ListItemFamilyResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ListItemFamilyResponseListObject {
-    
-        public ItemFamily $item_family;
-    
-public function __construct(
-    ItemFamily $item_family,
-){ 
-    $this->item_family = $item_family;
-
-}
-}
-
 ?>

--- a/src/Responses/ItemFamilyResponse/ListItemFamilyResponseListObject.php
+++ b/src/Responses/ItemFamilyResponse/ListItemFamilyResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\ItemFamilyResponse;
+
+use Chargebee\Resources\ItemFamily\ItemFamily;
+
+class ListItemFamilyResponseListObject
+{ 
+    public ItemFamily $item_family;
+    public function __construct(
+        ItemFamily $item_family,
+    ) { 
+        $this->item_family = $item_family;
+    }
+}

--- a/src/Responses/ItemPriceResponse/FindApplicableItemPricesItemPriceResponse.php
+++ b/src/Responses/ItemPriceResponse/FindApplicableItemPricesItemPriceResponse.php
@@ -51,18 +51,4 @@ class FindApplicableItemPricesItemPriceResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class FindApplicableItemPricesItemPriceResponseListObject {
-    
-        public ItemPrice $item_price;
-    
-public function __construct(
-    ItemPrice $item_price,
-){ 
-    $this->item_price = $item_price;
-
-}
-}
-
 ?>

--- a/src/Responses/ItemPriceResponse/FindApplicableItemPricesItemPriceResponseListObject.php
+++ b/src/Responses/ItemPriceResponse/FindApplicableItemPricesItemPriceResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\ItemPriceResponse;
+
+use Chargebee\Resources\ItemPrice\ItemPrice;
+
+class FindApplicableItemPricesItemPriceResponseListObject
+{ 
+    public ItemPrice $item_price;
+    public function __construct(
+        ItemPrice $item_price,
+    ) { 
+        $this->item_price = $item_price;
+    }
+}

--- a/src/Responses/ItemPriceResponse/FindApplicableItemsItemPriceResponse.php
+++ b/src/Responses/ItemPriceResponse/FindApplicableItemsItemPriceResponse.php
@@ -51,18 +51,4 @@ class FindApplicableItemsItemPriceResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class FindApplicableItemsItemPriceResponseListObject {
-    
-        public Item $item;
-    
-public function __construct(
-    Item $item,
-){ 
-    $this->item = $item;
-
-}
-}
-
 ?>

--- a/src/Responses/ItemPriceResponse/FindApplicableItemsItemPriceResponseListObject.php
+++ b/src/Responses/ItemPriceResponse/FindApplicableItemsItemPriceResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\ItemPriceResponse;
+
+use Chargebee\Resources\Item\Item;
+
+class FindApplicableItemsItemPriceResponseListObject
+{ 
+    public Item $item;
+    public function __construct(
+        Item $item,
+    ) { 
+        $this->item = $item;
+    }
+}

--- a/src/Responses/ItemPriceResponse/ListItemPriceResponse.php
+++ b/src/Responses/ItemPriceResponse/ListItemPriceResponse.php
@@ -51,18 +51,4 @@ class ListItemPriceResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ListItemPriceResponseListObject {
-    
-        public ItemPrice $item_price;
-    
-public function __construct(
-    ItemPrice $item_price,
-){ 
-    $this->item_price = $item_price;
-
-}
-}
-
 ?>

--- a/src/Responses/ItemPriceResponse/ListItemPriceResponseListObject.php
+++ b/src/Responses/ItemPriceResponse/ListItemPriceResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\ItemPriceResponse;
+
+use Chargebee\Resources\ItemPrice\ItemPrice;
+
+class ListItemPriceResponseListObject
+{ 
+    public ItemPrice $item_price;
+    public function __construct(
+        ItemPrice $item_price,
+    ) { 
+        $this->item_price = $item_price;
+    }
+}

--- a/src/Responses/ItemResponse/ListItemResponse.php
+++ b/src/Responses/ItemResponse/ListItemResponse.php
@@ -51,18 +51,4 @@ class ListItemResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ListItemResponseListObject {
-    
-        public Item $item;
-    
-public function __construct(
-    Item $item,
-){ 
-    $this->item = $item;
-
-}
-}
-
 ?>

--- a/src/Responses/ItemResponse/ListItemResponseListObject.php
+++ b/src/Responses/ItemResponse/ListItemResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\ItemResponse;
+
+use Chargebee\Resources\Item\Item;
+
+class ListItemResponseListObject
+{ 
+    public Item $item;
+    public function __construct(
+        Item $item,
+    ) { 
+        $this->item = $item;
+    }
+}

--- a/src/Responses/OmnichannelOneTimeOrderResponse/ListOmnichannelOneTimeOrderResponse.php
+++ b/src/Responses/OmnichannelOneTimeOrderResponse/ListOmnichannelOneTimeOrderResponse.php
@@ -51,18 +51,4 @@ class ListOmnichannelOneTimeOrderResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ListOmnichannelOneTimeOrderResponseListObject {
-    
-        public OmnichannelOneTimeOrder $omnichannel_one_time_order;
-    
-public function __construct(
-    OmnichannelOneTimeOrder $omnichannel_one_time_order,
-){ 
-    $this->omnichannel_one_time_order = $omnichannel_one_time_order;
-
-}
-}
-
 ?>

--- a/src/Responses/OmnichannelOneTimeOrderResponse/ListOmnichannelOneTimeOrderResponseListObject.php
+++ b/src/Responses/OmnichannelOneTimeOrderResponse/ListOmnichannelOneTimeOrderResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\OmnichannelOneTimeOrderResponse;
+
+use Chargebee\Resources\OmnichannelOneTimeOrder\OmnichannelOneTimeOrder;
+
+class ListOmnichannelOneTimeOrderResponseListObject
+{ 
+    public OmnichannelOneTimeOrder $omnichannel_one_time_order;
+    public function __construct(
+        OmnichannelOneTimeOrder $omnichannel_one_time_order,
+    ) { 
+        $this->omnichannel_one_time_order = $omnichannel_one_time_order;
+    }
+}

--- a/src/Responses/OmnichannelSubscriptionItemResponse/ListOmniSubItemScheduleChangesOmnichannelSubscriptionItemResponse.php
+++ b/src/Responses/OmnichannelSubscriptionItemResponse/ListOmniSubItemScheduleChangesOmnichannelSubscriptionItemResponse.php
@@ -51,18 +51,4 @@ class ListOmniSubItemScheduleChangesOmnichannelSubscriptionItemResponse extends 
         return $data;
     }
 }
-
-
-class ListOmniSubItemScheduleChangesOmnichannelSubscriptionItemResponseListObject {
-    
-        public OmnichannelSubscriptionItemScheduledChange $omnichannel_subscription_item_scheduled_change;
-    
-public function __construct(
-    OmnichannelSubscriptionItemScheduledChange $omnichannel_subscription_item_scheduled_change,
-){ 
-    $this->omnichannel_subscription_item_scheduled_change = $omnichannel_subscription_item_scheduled_change;
-
-}
-}
-
 ?>

--- a/src/Responses/OmnichannelSubscriptionItemResponse/ListOmniSubItemScheduleChangesOmnichannelSubscriptionItemResponseListObject.php
+++ b/src/Responses/OmnichannelSubscriptionItemResponse/ListOmniSubItemScheduleChangesOmnichannelSubscriptionItemResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\OmnichannelSubscriptionItemResponse;
+
+use Chargebee\Resources\OmnichannelSubscriptionItemScheduledChange\OmnichannelSubscriptionItemScheduledChange;
+
+class ListOmniSubItemScheduleChangesOmnichannelSubscriptionItemResponseListObject
+{ 
+    public OmnichannelSubscriptionItemScheduledChange $omnichannel_subscription_item_scheduled_change;
+    public function __construct(
+        OmnichannelSubscriptionItemScheduledChange $omnichannel_subscription_item_scheduled_change,
+    ) { 
+        $this->omnichannel_subscription_item_scheduled_change = $omnichannel_subscription_item_scheduled_change;
+    }
+}

--- a/src/Responses/OmnichannelSubscriptionResponse/ListOmnichannelSubscriptionResponse.php
+++ b/src/Responses/OmnichannelSubscriptionResponse/ListOmnichannelSubscriptionResponse.php
@@ -51,18 +51,4 @@ class ListOmnichannelSubscriptionResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ListOmnichannelSubscriptionResponseListObject {
-    
-        public OmnichannelSubscription $omnichannel_subscription;
-    
-public function __construct(
-    OmnichannelSubscription $omnichannel_subscription,
-){ 
-    $this->omnichannel_subscription = $omnichannel_subscription;
-
-}
-}
-
 ?>

--- a/src/Responses/OmnichannelSubscriptionResponse/ListOmnichannelSubscriptionResponseListObject.php
+++ b/src/Responses/OmnichannelSubscriptionResponse/ListOmnichannelSubscriptionResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\OmnichannelSubscriptionResponse;
+
+use Chargebee\Resources\OmnichannelSubscription\OmnichannelSubscription;
+
+class ListOmnichannelSubscriptionResponseListObject
+{ 
+    public OmnichannelSubscription $omnichannel_subscription;
+    public function __construct(
+        OmnichannelSubscription $omnichannel_subscription,
+    ) { 
+        $this->omnichannel_subscription = $omnichannel_subscription;
+    }
+}

--- a/src/Responses/OmnichannelSubscriptionResponse/OmnichannelTransactionsForOmnichannelSubscriptionOmnichannelSubscriptionResponse.php
+++ b/src/Responses/OmnichannelSubscriptionResponse/OmnichannelTransactionsForOmnichannelSubscriptionOmnichannelSubscriptionResponse.php
@@ -51,18 +51,4 @@ class OmnichannelTransactionsForOmnichannelSubscriptionOmnichannelSubscriptionRe
         return $data;
     }
 }
-
-
-class OmnichannelTransactionsForOmnichannelSubscriptionOmnichannelSubscriptionResponseListObject {
-    
-        public OmnichannelTransaction $omnichannel_transaction;
-    
-public function __construct(
-    OmnichannelTransaction $omnichannel_transaction,
-){ 
-    $this->omnichannel_transaction = $omnichannel_transaction;
-
-}
-}
-
 ?>

--- a/src/Responses/OmnichannelSubscriptionResponse/OmnichannelTransactionsForOmnichannelSubscriptionOmnichannelSubscriptionResponseListObject.php
+++ b/src/Responses/OmnichannelSubscriptionResponse/OmnichannelTransactionsForOmnichannelSubscriptionOmnichannelSubscriptionResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\OmnichannelSubscriptionResponse;
+
+use Chargebee\Resources\OmnichannelTransaction\OmnichannelTransaction;
+
+class OmnichannelTransactionsForOmnichannelSubscriptionOmnichannelSubscriptionResponseListObject
+{ 
+    public OmnichannelTransaction $omnichannel_transaction;
+    public function __construct(
+        OmnichannelTransaction $omnichannel_transaction,
+    ) { 
+        $this->omnichannel_transaction = $omnichannel_transaction;
+    }
+}

--- a/src/Responses/OrderResponse/ListOrderResponse.php
+++ b/src/Responses/OrderResponse/ListOrderResponse.php
@@ -51,18 +51,4 @@ class ListOrderResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ListOrderResponseListObject {
-    
-        public Order $order;
-    
-public function __construct(
-    Order $order,
-){ 
-    $this->order = $order;
-
-}
-}
-
 ?>

--- a/src/Responses/OrderResponse/ListOrderResponseListObject.php
+++ b/src/Responses/OrderResponse/ListOrderResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\OrderResponse;
+
+use Chargebee\Resources\Order\Order;
+
+class ListOrderResponseListObject
+{ 
+    public Order $order;
+    public function __construct(
+        Order $order,
+    ) { 
+        $this->order = $order;
+    }
+}

--- a/src/Responses/OrderResponse/OrdersForInvoiceOrderResponse.php
+++ b/src/Responses/OrderResponse/OrdersForInvoiceOrderResponse.php
@@ -51,18 +51,4 @@ class OrdersForInvoiceOrderResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class OrdersForInvoiceOrderResponseListObject {
-    
-        public Order $order;
-    
-public function __construct(
-    Order $order,
-){ 
-    $this->order = $order;
-
-}
-}
-
 ?>

--- a/src/Responses/OrderResponse/OrdersForInvoiceOrderResponseListObject.php
+++ b/src/Responses/OrderResponse/OrdersForInvoiceOrderResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\OrderResponse;
+
+use Chargebee\Resources\Order\Order;
+
+class OrdersForInvoiceOrderResponseListObject
+{ 
+    public Order $order;
+    public function __construct(
+        Order $order,
+    ) { 
+        $this->order = $order;
+    }
+}

--- a/src/Responses/PaymentSourceResponse/ListPaymentSourceResponse.php
+++ b/src/Responses/PaymentSourceResponse/ListPaymentSourceResponse.php
@@ -51,18 +51,4 @@ class ListPaymentSourceResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ListPaymentSourceResponseListObject {
-    
-        public PaymentSource $payment_source;
-    
-public function __construct(
-    PaymentSource $payment_source,
-){ 
-    $this->payment_source = $payment_source;
-
-}
-}
-
 ?>

--- a/src/Responses/PaymentSourceResponse/ListPaymentSourceResponseListObject.php
+++ b/src/Responses/PaymentSourceResponse/ListPaymentSourceResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\PaymentSourceResponse;
+
+use Chargebee\Resources\PaymentSource\PaymentSource;
+
+class ListPaymentSourceResponseListObject
+{ 
+    public PaymentSource $payment_source;
+    public function __construct(
+        PaymentSource $payment_source,
+    ) { 
+        $this->payment_source = $payment_source;
+    }
+}

--- a/src/Responses/PaymentVoucherResponse/PaymentVouchersForCustomerPaymentVoucherResponse.php
+++ b/src/Responses/PaymentVoucherResponse/PaymentVouchersForCustomerPaymentVoucherResponse.php
@@ -51,18 +51,4 @@ class PaymentVouchersForCustomerPaymentVoucherResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class PaymentVouchersForCustomerPaymentVoucherResponseListObject {
-    
-        public PaymentVoucher $payment_voucher;
-    
-public function __construct(
-    PaymentVoucher $payment_voucher,
-){ 
-    $this->payment_voucher = $payment_voucher;
-
-}
-}
-
 ?>

--- a/src/Responses/PaymentVoucherResponse/PaymentVouchersForCustomerPaymentVoucherResponseListObject.php
+++ b/src/Responses/PaymentVoucherResponse/PaymentVouchersForCustomerPaymentVoucherResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\PaymentVoucherResponse;
+
+use Chargebee\Resources\PaymentVoucher\PaymentVoucher;
+
+class PaymentVouchersForCustomerPaymentVoucherResponseListObject
+{ 
+    public PaymentVoucher $payment_voucher;
+    public function __construct(
+        PaymentVoucher $payment_voucher,
+    ) { 
+        $this->payment_voucher = $payment_voucher;
+    }
+}

--- a/src/Responses/PaymentVoucherResponse/PaymentVouchersForInvoicePaymentVoucherResponse.php
+++ b/src/Responses/PaymentVoucherResponse/PaymentVouchersForInvoicePaymentVoucherResponse.php
@@ -51,18 +51,4 @@ class PaymentVouchersForInvoicePaymentVoucherResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class PaymentVouchersForInvoicePaymentVoucherResponseListObject {
-    
-        public PaymentVoucher $payment_voucher;
-    
-public function __construct(
-    PaymentVoucher $payment_voucher,
-){ 
-    $this->payment_voucher = $payment_voucher;
-
-}
-}
-
 ?>

--- a/src/Responses/PaymentVoucherResponse/PaymentVouchersForInvoicePaymentVoucherResponseListObject.php
+++ b/src/Responses/PaymentVoucherResponse/PaymentVouchersForInvoicePaymentVoucherResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\PaymentVoucherResponse;
+
+use Chargebee\Resources\PaymentVoucher\PaymentVoucher;
+
+class PaymentVouchersForInvoicePaymentVoucherResponseListObject
+{ 
+    public PaymentVoucher $payment_voucher;
+    public function __construct(
+        PaymentVoucher $payment_voucher,
+    ) { 
+        $this->payment_voucher = $payment_voucher;
+    }
+}

--- a/src/Responses/PlanResponse/ListPlanResponse.php
+++ b/src/Responses/PlanResponse/ListPlanResponse.php
@@ -51,18 +51,4 @@ class ListPlanResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ListPlanResponseListObject {
-    
-        public Plan $plan;
-    
-public function __construct(
-    Plan $plan,
-){ 
-    $this->plan = $plan;
-
-}
-}
-
 ?>

--- a/src/Responses/PlanResponse/ListPlanResponseListObject.php
+++ b/src/Responses/PlanResponse/ListPlanResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\PlanResponse;
+
+use Chargebee\Resources\Plan\Plan;
+
+class ListPlanResponseListObject
+{ 
+    public Plan $plan;
+    public function __construct(
+        Plan $plan,
+    ) { 
+        $this->plan = $plan;
+    }
+}

--- a/src/Responses/PriceVariantResponse/ListPriceVariantResponse.php
+++ b/src/Responses/PriceVariantResponse/ListPriceVariantResponse.php
@@ -51,18 +51,4 @@ class ListPriceVariantResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ListPriceVariantResponseListObject {
-    
-        public PriceVariant $price_variant;
-    
-public function __construct(
-    PriceVariant $price_variant,
-){ 
-    $this->price_variant = $price_variant;
-
-}
-}
-
 ?>

--- a/src/Responses/PriceVariantResponse/ListPriceVariantResponseListObject.php
+++ b/src/Responses/PriceVariantResponse/ListPriceVariantResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\PriceVariantResponse;
+
+use Chargebee\Resources\PriceVariant\PriceVariant;
+
+class ListPriceVariantResponseListObject
+{ 
+    public PriceVariant $price_variant;
+    public function __construct(
+        PriceVariant $price_variant,
+    ) { 
+        $this->price_variant = $price_variant;
+    }
+}

--- a/src/Responses/PromotionalCreditResponse/ListPromotionalCreditResponse.php
+++ b/src/Responses/PromotionalCreditResponse/ListPromotionalCreditResponse.php
@@ -51,18 +51,4 @@ class ListPromotionalCreditResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ListPromotionalCreditResponseListObject {
-    
-        public PromotionalCredit $promotional_credit;
-    
-public function __construct(
-    PromotionalCredit $promotional_credit,
-){ 
-    $this->promotional_credit = $promotional_credit;
-
-}
-}
-
 ?>

--- a/src/Responses/PromotionalCreditResponse/ListPromotionalCreditResponseListObject.php
+++ b/src/Responses/PromotionalCreditResponse/ListPromotionalCreditResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\PromotionalCreditResponse;
+
+use Chargebee\Resources\PromotionalCredit\PromotionalCredit;
+
+class ListPromotionalCreditResponseListObject
+{ 
+    public PromotionalCredit $promotional_credit;
+    public function __construct(
+        PromotionalCredit $promotional_credit,
+    ) { 
+        $this->promotional_credit = $promotional_credit;
+    }
+}

--- a/src/Responses/QuoteResponse/ListQuoteResponse.php
+++ b/src/Responses/QuoteResponse/ListQuoteResponse.php
@@ -57,30 +57,4 @@ class ListQuoteResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ListQuoteResponseListObject {
-    
-        public Quote $quote;
-    
-        public ?QuotedSubscription $quoted_subscription;
-    
-        public ?QuotedRamp $quoted_ramp;
-    
-public function __construct(
-    Quote $quote,
-
-    ?QuotedSubscription $quoted_subscription,
-
-    ?QuotedRamp $quoted_ramp,
-){ 
-    $this->quote = $quote;
-
-    $this->quoted_subscription = $quoted_subscription;
-
-    $this->quoted_ramp = $quoted_ramp;
-
-}
-}
-
 ?>

--- a/src/Responses/QuoteResponse/ListQuoteResponseListObject.php
+++ b/src/Responses/QuoteResponse/ListQuoteResponseListObject.php
@@ -1,0 +1,26 @@
+<?php
+namespace Chargebee\Responses\QuoteResponse;
+
+use Chargebee\Resources\Quote\Quote;
+use Chargebee\Resources\QuotedSubscription\QuotedSubscription;
+use Chargebee\Resources\QuotedRamp\QuotedRamp;
+
+class ListQuoteResponseListObject
+{ 
+    public Quote $quote;
+
+    public ?QuotedSubscription $quoted_subscription;
+
+    public ?QuotedRamp $quoted_ramp;
+    public function __construct(
+        Quote $quote,
+    
+        ?QuotedSubscription $quoted_subscription,
+    
+        ?QuotedRamp $quoted_ramp,
+    ) { 
+        $this->quote = $quote;
+        $this->quoted_subscription = $quoted_subscription;
+        $this->quoted_ramp = $quoted_ramp;
+    }
+}

--- a/src/Responses/QuoteResponse/QuoteLineGroupsForQuoteQuoteResponse.php
+++ b/src/Responses/QuoteResponse/QuoteLineGroupsForQuoteQuoteResponse.php
@@ -51,18 +51,4 @@ class QuoteLineGroupsForQuoteQuoteResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class QuoteLineGroupsForQuoteQuoteResponseListObject {
-    
-        public QuoteLineGroup $quote_line_group;
-    
-public function __construct(
-    QuoteLineGroup $quote_line_group,
-){ 
-    $this->quote_line_group = $quote_line_group;
-
-}
-}
-
 ?>

--- a/src/Responses/QuoteResponse/QuoteLineGroupsForQuoteQuoteResponseListObject.php
+++ b/src/Responses/QuoteResponse/QuoteLineGroupsForQuoteQuoteResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\QuoteResponse;
+
+use Chargebee\Resources\QuoteLineGroup\QuoteLineGroup;
+
+class QuoteLineGroupsForQuoteQuoteResponseListObject
+{ 
+    public QuoteLineGroup $quote_line_group;
+    public function __construct(
+        QuoteLineGroup $quote_line_group,
+    ) { 
+        $this->quote_line_group = $quote_line_group;
+    }
+}

--- a/src/Responses/RampResponse/ListRampResponse.php
+++ b/src/Responses/RampResponse/ListRampResponse.php
@@ -51,18 +51,4 @@ class ListRampResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ListRampResponseListObject {
-    
-        public Ramp $ramp;
-    
-public function __construct(
-    Ramp $ramp,
-){ 
-    $this->ramp = $ramp;
-
-}
-}
-
 ?>

--- a/src/Responses/RampResponse/ListRampResponseListObject.php
+++ b/src/Responses/RampResponse/ListRampResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\RampResponse;
+
+use Chargebee\Resources\Ramp\Ramp;
+
+class ListRampResponseListObject
+{ 
+    public Ramp $ramp;
+    public function __construct(
+        Ramp $ramp,
+    ) { 
+        $this->ramp = $ramp;
+    }
+}

--- a/src/Responses/SiteMigrationDetailResponse/ListSiteMigrationDetailResponse.php
+++ b/src/Responses/SiteMigrationDetailResponse/ListSiteMigrationDetailResponse.php
@@ -51,18 +51,4 @@ class ListSiteMigrationDetailResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ListSiteMigrationDetailResponseListObject {
-    
-        public SiteMigrationDetail $site_migration_detail;
-    
-public function __construct(
-    SiteMigrationDetail $site_migration_detail,
-){ 
-    $this->site_migration_detail = $site_migration_detail;
-
-}
-}
-
 ?>

--- a/src/Responses/SiteMigrationDetailResponse/ListSiteMigrationDetailResponseListObject.php
+++ b/src/Responses/SiteMigrationDetailResponse/ListSiteMigrationDetailResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\SiteMigrationDetailResponse;
+
+use Chargebee\Resources\SiteMigrationDetail\SiteMigrationDetail;
+
+class ListSiteMigrationDetailResponseListObject
+{ 
+    public SiteMigrationDetail $site_migration_detail;
+    public function __construct(
+        SiteMigrationDetail $site_migration_detail,
+    ) { 
+        $this->site_migration_detail = $site_migration_detail;
+    }
+}

--- a/src/Responses/SubscriptionEntitlementResponse/SubscriptionEntitlementsForSubscriptionSubscriptionEntitlementResponse.php
+++ b/src/Responses/SubscriptionEntitlementResponse/SubscriptionEntitlementsForSubscriptionSubscriptionEntitlementResponse.php
@@ -51,18 +51,4 @@ class SubscriptionEntitlementsForSubscriptionSubscriptionEntitlementResponse ext
         return $data;
     }
 }
-
-
-class SubscriptionEntitlementsForSubscriptionSubscriptionEntitlementResponseListObject {
-    
-        public SubscriptionEntitlement $subscription_entitlement;
-    
-public function __construct(
-    SubscriptionEntitlement $subscription_entitlement,
-){ 
-    $this->subscription_entitlement = $subscription_entitlement;
-
-}
-}
-
 ?>

--- a/src/Responses/SubscriptionEntitlementResponse/SubscriptionEntitlementsForSubscriptionSubscriptionEntitlementResponseListObject.php
+++ b/src/Responses/SubscriptionEntitlementResponse/SubscriptionEntitlementsForSubscriptionSubscriptionEntitlementResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\SubscriptionEntitlementResponse;
+
+use Chargebee\Resources\SubscriptionEntitlement\SubscriptionEntitlement;
+
+class SubscriptionEntitlementsForSubscriptionSubscriptionEntitlementResponseListObject
+{ 
+    public SubscriptionEntitlement $subscription_entitlement;
+    public function __construct(
+        SubscriptionEntitlement $subscription_entitlement,
+    ) { 
+        $this->subscription_entitlement = $subscription_entitlement;
+    }
+}

--- a/src/Responses/SubscriptionResponse/ContractTermsForSubscriptionSubscriptionResponse.php
+++ b/src/Responses/SubscriptionResponse/ContractTermsForSubscriptionSubscriptionResponse.php
@@ -51,18 +51,4 @@ class ContractTermsForSubscriptionSubscriptionResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ContractTermsForSubscriptionSubscriptionResponseListObject {
-    
-        public ContractTerm $contract_term;
-    
-public function __construct(
-    ContractTerm $contract_term,
-){ 
-    $this->contract_term = $contract_term;
-
-}
-}
-
 ?>

--- a/src/Responses/SubscriptionResponse/ContractTermsForSubscriptionSubscriptionResponseListObject.php
+++ b/src/Responses/SubscriptionResponse/ContractTermsForSubscriptionSubscriptionResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\SubscriptionResponse;
+
+use Chargebee\Resources\ContractTerm\ContractTerm;
+
+class ContractTermsForSubscriptionSubscriptionResponseListObject
+{ 
+    public ContractTerm $contract_term;
+    public function __construct(
+        ContractTerm $contract_term,
+    ) { 
+        $this->contract_term = $contract_term;
+    }
+}

--- a/src/Responses/SubscriptionResponse/ListDiscountsSubscriptionResponse.php
+++ b/src/Responses/SubscriptionResponse/ListDiscountsSubscriptionResponse.php
@@ -51,18 +51,4 @@ class ListDiscountsSubscriptionResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ListDiscountsSubscriptionResponseListObject {
-    
-        public Discount $discount;
-    
-public function __construct(
-    Discount $discount,
-){ 
-    $this->discount = $discount;
-
-}
-}
-
 ?>

--- a/src/Responses/SubscriptionResponse/ListDiscountsSubscriptionResponseListObject.php
+++ b/src/Responses/SubscriptionResponse/ListDiscountsSubscriptionResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\SubscriptionResponse;
+
+use Chargebee\Resources\Discount\Discount;
+
+class ListDiscountsSubscriptionResponseListObject
+{ 
+    public Discount $discount;
+    public function __construct(
+        Discount $discount,
+    ) { 
+        $this->discount = $discount;
+    }
+}

--- a/src/Responses/SubscriptionResponse/ListSubscriptionResponse.php
+++ b/src/Responses/SubscriptionResponse/ListSubscriptionResponse.php
@@ -57,30 +57,4 @@ class ListSubscriptionResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ListSubscriptionResponseListObject {
-    
-        public Subscription $subscription;
-    
-        public Customer $customer;
-    
-        public ?Card $card;
-    
-public function __construct(
-    Subscription $subscription,
-
-    Customer $customer,
-
-    ?Card $card,
-){ 
-    $this->subscription = $subscription;
-
-    $this->customer = $customer;
-
-    $this->card = $card;
-
-}
-}
-
 ?>

--- a/src/Responses/SubscriptionResponse/ListSubscriptionResponseListObject.php
+++ b/src/Responses/SubscriptionResponse/ListSubscriptionResponseListObject.php
@@ -1,0 +1,26 @@
+<?php
+namespace Chargebee\Responses\SubscriptionResponse;
+
+use Chargebee\Resources\Subscription\Subscription;
+use Chargebee\Resources\Customer\Customer;
+use Chargebee\Resources\Card\Card;
+
+class ListSubscriptionResponseListObject
+{ 
+    public Subscription $subscription;
+
+    public Customer $customer;
+
+    public ?Card $card;
+    public function __construct(
+        Subscription $subscription,
+    
+        Customer $customer,
+    
+        ?Card $card,
+    ) { 
+        $this->subscription = $subscription;
+        $this->customer = $customer;
+        $this->card = $card;
+    }
+}

--- a/src/Responses/SubscriptionResponse/SubscriptionsForCustomerSubscriptionResponse.php
+++ b/src/Responses/SubscriptionResponse/SubscriptionsForCustomerSubscriptionResponse.php
@@ -51,18 +51,4 @@ class SubscriptionsForCustomerSubscriptionResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class SubscriptionsForCustomerSubscriptionResponseListObject {
-    
-        public Subscription $subscription;
-    
-public function __construct(
-    Subscription $subscription,
-){ 
-    $this->subscription = $subscription;
-
-}
-}
-
 ?>

--- a/src/Responses/SubscriptionResponse/SubscriptionsForCustomerSubscriptionResponseListObject.php
+++ b/src/Responses/SubscriptionResponse/SubscriptionsForCustomerSubscriptionResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\SubscriptionResponse;
+
+use Chargebee\Resources\Subscription\Subscription;
+
+class SubscriptionsForCustomerSubscriptionResponseListObject
+{ 
+    public Subscription $subscription;
+    public function __construct(
+        Subscription $subscription,
+    ) { 
+        $this->subscription = $subscription;
+    }
+}

--- a/src/Responses/TransactionResponse/ListTransactionResponse.php
+++ b/src/Responses/TransactionResponse/ListTransactionResponse.php
@@ -51,18 +51,4 @@ class ListTransactionResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ListTransactionResponseListObject {
-    
-        public Transaction $transaction;
-    
-public function __construct(
-    Transaction $transaction,
-){ 
-    $this->transaction = $transaction;
-
-}
-}
-
 ?>

--- a/src/Responses/TransactionResponse/ListTransactionResponseListObject.php
+++ b/src/Responses/TransactionResponse/ListTransactionResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\TransactionResponse;
+
+use Chargebee\Resources\Transaction\Transaction;
+
+class ListTransactionResponseListObject
+{ 
+    public Transaction $transaction;
+    public function __construct(
+        Transaction $transaction,
+    ) { 
+        $this->transaction = $transaction;
+    }
+}

--- a/src/Responses/TransactionResponse/PaymentsForInvoiceTransactionResponse.php
+++ b/src/Responses/TransactionResponse/PaymentsForInvoiceTransactionResponse.php
@@ -51,18 +51,4 @@ class PaymentsForInvoiceTransactionResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class PaymentsForInvoiceTransactionResponseListObject {
-    
-        public Transaction $transaction;
-    
-public function __construct(
-    Transaction $transaction,
-){ 
-    $this->transaction = $transaction;
-
-}
-}
-
 ?>

--- a/src/Responses/TransactionResponse/PaymentsForInvoiceTransactionResponseListObject.php
+++ b/src/Responses/TransactionResponse/PaymentsForInvoiceTransactionResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\TransactionResponse;
+
+use Chargebee\Resources\Transaction\Transaction;
+
+class PaymentsForInvoiceTransactionResponseListObject
+{ 
+    public Transaction $transaction;
+    public function __construct(
+        Transaction $transaction,
+    ) { 
+        $this->transaction = $transaction;
+    }
+}

--- a/src/Responses/TransactionResponse/TransactionsForCustomerTransactionResponse.php
+++ b/src/Responses/TransactionResponse/TransactionsForCustomerTransactionResponse.php
@@ -51,18 +51,4 @@ class TransactionsForCustomerTransactionResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class TransactionsForCustomerTransactionResponseListObject {
-    
-        public Transaction $transaction;
-    
-public function __construct(
-    Transaction $transaction,
-){ 
-    $this->transaction = $transaction;
-
-}
-}
-
 ?>

--- a/src/Responses/TransactionResponse/TransactionsForCustomerTransactionResponseListObject.php
+++ b/src/Responses/TransactionResponse/TransactionsForCustomerTransactionResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\TransactionResponse;
+
+use Chargebee\Resources\Transaction\Transaction;
+
+class TransactionsForCustomerTransactionResponseListObject
+{ 
+    public Transaction $transaction;
+    public function __construct(
+        Transaction $transaction,
+    ) { 
+        $this->transaction = $transaction;
+    }
+}

--- a/src/Responses/TransactionResponse/TransactionsForSubscriptionTransactionResponse.php
+++ b/src/Responses/TransactionResponse/TransactionsForSubscriptionTransactionResponse.php
@@ -51,18 +51,4 @@ class TransactionsForSubscriptionTransactionResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class TransactionsForSubscriptionTransactionResponseListObject {
-    
-        public Transaction $transaction;
-    
-public function __construct(
-    Transaction $transaction,
-){ 
-    $this->transaction = $transaction;
-
-}
-}
-
 ?>

--- a/src/Responses/TransactionResponse/TransactionsForSubscriptionTransactionResponseListObject.php
+++ b/src/Responses/TransactionResponse/TransactionsForSubscriptionTransactionResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\TransactionResponse;
+
+use Chargebee\Resources\Transaction\Transaction;
+
+class TransactionsForSubscriptionTransactionResponseListObject
+{ 
+    public Transaction $transaction;
+    public function __construct(
+        Transaction $transaction,
+    ) { 
+        $this->transaction = $transaction;
+    }
+}

--- a/src/Responses/UnbilledChargeResponse/ListUnbilledChargeResponse.php
+++ b/src/Responses/UnbilledChargeResponse/ListUnbilledChargeResponse.php
@@ -51,18 +51,4 @@ class ListUnbilledChargeResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ListUnbilledChargeResponseListObject {
-    
-        public UnbilledCharge $unbilled_charge;
-    
-public function __construct(
-    UnbilledCharge $unbilled_charge,
-){ 
-    $this->unbilled_charge = $unbilled_charge;
-
-}
-}
-
 ?>

--- a/src/Responses/UnbilledChargeResponse/ListUnbilledChargeResponseListObject.php
+++ b/src/Responses/UnbilledChargeResponse/ListUnbilledChargeResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\UnbilledChargeResponse;
+
+use Chargebee\Resources\UnbilledCharge\UnbilledCharge;
+
+class ListUnbilledChargeResponseListObject
+{ 
+    public UnbilledCharge $unbilled_charge;
+    public function __construct(
+        UnbilledCharge $unbilled_charge,
+    ) { 
+        $this->unbilled_charge = $unbilled_charge;
+    }
+}

--- a/src/Responses/UsageResponse/ListUsageResponse.php
+++ b/src/Responses/UsageResponse/ListUsageResponse.php
@@ -51,18 +51,4 @@ class ListUsageResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ListUsageResponseListObject {
-    
-        public Usage $usage;
-    
-public function __construct(
-    Usage $usage,
-){ 
-    $this->usage = $usage;
-
-}
-}
-
 ?>

--- a/src/Responses/UsageResponse/ListUsageResponseListObject.php
+++ b/src/Responses/UsageResponse/ListUsageResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\UsageResponse;
+
+use Chargebee\Resources\Usage\Usage;
+
+class ListUsageResponseListObject
+{ 
+    public Usage $usage;
+    public function __construct(
+        Usage $usage,
+    ) { 
+        $this->usage = $usage;
+    }
+}

--- a/src/Responses/VirtualBankAccountResponse/ListVirtualBankAccountResponse.php
+++ b/src/Responses/VirtualBankAccountResponse/ListVirtualBankAccountResponse.php
@@ -51,18 +51,4 @@ class ListVirtualBankAccountResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ListVirtualBankAccountResponseListObject {
-    
-        public VirtualBankAccount $virtual_bank_account;
-    
-public function __construct(
-    VirtualBankAccount $virtual_bank_account,
-){ 
-    $this->virtual_bank_account = $virtual_bank_account;
-
-}
-}
-
 ?>

--- a/src/Responses/VirtualBankAccountResponse/ListVirtualBankAccountResponseListObject.php
+++ b/src/Responses/VirtualBankAccountResponse/ListVirtualBankAccountResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\VirtualBankAccountResponse;
+
+use Chargebee\Resources\VirtualBankAccount\VirtualBankAccount;
+
+class ListVirtualBankAccountResponseListObject
+{ 
+    public VirtualBankAccount $virtual_bank_account;
+    public function __construct(
+        VirtualBankAccount $virtual_bank_account,
+    ) { 
+        $this->virtual_bank_account = $virtual_bank_account;
+    }
+}

--- a/src/Responses/WebhookEndpointResponse/ListWebhookEndpointResponse.php
+++ b/src/Responses/WebhookEndpointResponse/ListWebhookEndpointResponse.php
@@ -51,18 +51,4 @@ class ListWebhookEndpointResponse extends ResponseBase {
         return $data;
     }
 }
-
-
-class ListWebhookEndpointResponseListObject {
-    
-        public WebhookEndpoint $webhook_endpoint;
-    
-public function __construct(
-    WebhookEndpoint $webhook_endpoint,
-){ 
-    $this->webhook_endpoint = $webhook_endpoint;
-
-}
-}
-
 ?>

--- a/src/Responses/WebhookEndpointResponse/ListWebhookEndpointResponseListObject.php
+++ b/src/Responses/WebhookEndpointResponse/ListWebhookEndpointResponseListObject.php
@@ -1,0 +1,14 @@
+<?php
+namespace Chargebee\Responses\WebhookEndpointResponse;
+
+use Chargebee\Resources\WebhookEndpoint\WebhookEndpoint;
+
+class ListWebhookEndpointResponseListObject
+{ 
+    public WebhookEndpoint $webhook_endpoint;
+    public function __construct(
+        WebhookEndpoint $webhook_endpoint,
+    ) { 
+        $this->webhook_endpoint = $webhook_endpoint;
+    }
+}

--- a/src/ValueObjects/APIRequester.php
+++ b/src/ValueObjects/APIRequester.php
@@ -48,6 +48,12 @@ class APIRequester
 
     /**
      * Sends the actual HTTP request.
+     * @throws PaymentException
+     * @throws ClientExceptionInterface
+     * @throws OperationFailedException
+     * @throws APIError
+     * @throws InvalidRequestException
+     * @throws \Exception
      */
     private function sendRequest(ChargebeePayload $payload, int $retryCount): ResponseObject
     {
@@ -156,9 +162,12 @@ class APIRequester
         if (method_exists($err, 'getHttpStatusCode')) {
             return $err->getHttpStatusCode();
         }
-        
-        if (method_exists($err, 'getResponse') && method_exists($err->getResponse(), 'getStatusCode')) {
-            return $err->getResponse()->getStatusCode();
+
+        if (method_exists($err, 'getResponse')) {
+            $response = $err->getResponse();
+            if (is_object($response) && method_exists($response, 'getStatusCode')) {
+                return $response->getStatusCode();
+            }
         }
         
         // Fall back to error code, which might not be an HTTP status code

--- a/src/ValueObjects/APIRequester.php
+++ b/src/ValueObjects/APIRequester.php
@@ -10,6 +10,7 @@ use Chargebee\Exceptions\PaymentException;
 use Chargebee\RetryConfig;
 use Chargebee\ValueObjects\Transporters\ChargebeePayload;
 use Chargebee\HttpClient\HttpClientFactory;
+use Exception;
 use Psr\Http\Client\ClientExceptionInterface;
 
 class APIRequester
@@ -32,11 +33,10 @@ class APIRequester
      * Makes an API request with retry logic.
      *
      * @throws PaymentException
-     * @throws ClientExceptionInterface
      * @throws OperationFailedException
      * @throws APIError
      * @throws InvalidRequestException
-     * @throws \Exception
+     * @throws Exception
      */
     public function makeRequest(ChargebeePayload $payload): ResponseObject
     {
@@ -53,7 +53,7 @@ class APIRequester
      * @throws OperationFailedException
      * @throws APIError
      * @throws InvalidRequestException
-     * @throws \Exception
+     * @throws Exception
      */
     private function sendRequest(ChargebeePayload $payload, int $retryCount): ResponseObject
     {
@@ -77,7 +77,7 @@ class APIRequester
      * @param RetryConfig $retryConfig The retry configuration
      * @param int $retryCount The current retry attempt (0 for initial request)
      * @return ResponseObject The response from the API
-     * @throws \Exception If all retries fail
+     * @throws Exception If all retries fail
      */
     private function withRetry(callable $makeRequest, RetryConfig $retryConfig, int $retryCount = 0): ResponseObject
     {
@@ -107,7 +107,7 @@ class APIRequester
             
             // Retry the request recursively
             return $this->withRetry($makeRequest, $retryConfig, $retryCount + 1);
-        } catch (\Exception $err) {
+        } catch (Exception $err) {
             // Handle generic exceptions
             $statusCode = $this->extractStatusCodeFromException($err);
             
@@ -135,7 +135,7 @@ class APIRequester
     /**
      * Handles rate limit (429) errors with Retry-After header.
      */
-    private function handleRateLimitError(\Exception $err, callable $makeRequest, RetryConfig $retryConfig, int $retryCount): ResponseObject
+    private function handleRateLimitError(Exception $err, callable $makeRequest, RetryConfig $retryConfig, int $retryCount): ResponseObject
     {
         $headers = method_exists($err, 'getHeaders') ? $err->getHeaders() : [];
         $retryAfterHeader = $headers['retry-after'] ?? $headers['Retry-After'] ?? '';
@@ -156,7 +156,7 @@ class APIRequester
     /**
      * Extracts HTTP status code from generic exceptions.
      */
-    private function extractStatusCodeFromException(\Exception $err): int
+    private function extractStatusCodeFromException(Exception $err): int
     {
         // Try various methods to get the status code
         if (method_exists($err, 'getHttpStatusCode')) {

--- a/src/ValueObjects/Encoders/URLFormEncoder.php
+++ b/src/ValueObjects/Encoders/URLFormEncoder.php
@@ -25,7 +25,8 @@ class URLFormEncoder implements ParamEncoderInterface
 
         $serialized = [];
         foreach ($value as $k => $v) {
-            $shouldJsonEncode = isset($jsonKeys[$k]) && $jsonKeys[$k] === $level;
+            $camelCaseKey = Util::toCamelCaseFromUnderscore($k);
+            $shouldJsonEncode = isset($jsonKeys[$camelCaseKey]) && $jsonKeys[$camelCaseKey] === $level;
             if ($shouldJsonEncode) {
                 $usK = Util::toUnderscoreFromCamelCase($k);
                 $key = (!is_null($prefix) ? $prefix : '') .

--- a/src/Version.php
+++ b/src/Version.php
@@ -4,7 +4,7 @@ namespace Chargebee;
 
 final class Version
 {
-	const VERSION = '4.8.1';
+	const VERSION = '4.9.0';
 }
 
 ?>

--- a/src/Version.php
+++ b/src/Version.php
@@ -4,7 +4,7 @@ namespace Chargebee;
 
 final class Version
 {
-	const VERSION = '4.8.0';
+	const VERSION = '4.8.1';
 }
 
 ?>

--- a/tests/ValueObjects/Encoder/URLFormEncoderTest.php
+++ b/tests/ValueObjects/Encoder/URLFormEncoderTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\ValueObjects\Encoders;
+
+use Chargebee\ValueObjects\Encoders\URLFormEncoder;
+use PHPUnit\Framework\TestCase;
+
+final class URLFormEncoderTest extends TestCase
+{
+    /** Should convert params to URL Form Encode */
+    /**  first_name first_name=John&last_name=Doe&email=john@test.com&locale=fr-CA */
+    public function testEncodeParamsWithSimpleAttributes(): void
+    {
+        $params = [
+            "first_name" => "John",
+            "last_name" => "Doe",
+            "email" => "john@test.com",
+            "locale" => "fr-CA",
+        ];
+        $encoded = URLFormEncoder::encode($params);
+        $this->assertIsString($encoded);
+        $this->assertSame("first_name=John&last_name=Doe&email=john%40test.com&locale=fr-CA", $encoded);
+    }
+
+    /** Should convert params to URL Form Encode */
+    /**  first_name=John&last_name=Doe&coupon[0]=FIFTYOFF&coupon[1]=TENOFF */
+    public function testEncodeParamsWithAttributeAsArrayOfPrimitives(): void
+    {
+        $params = [
+            "first_name" => "John",
+            "last_name" => "Doe",
+            "coupon" => [ "FIFTYOFF", "TENOFF"]
+        ];
+        $encoded = URLFormEncoder::encode($params);
+        $this->assertIsString($encoded);
+        $this->assertSame("first_name=John&last_name=Doe&coupon%5B0%5D=FIFTYOFF&coupon%5B1%5D=TENOFF", $encoded);
+    }
+
+    /** Should convert params to URL Form Encode */
+    /** first_name=John&last_name=Doe&billing_address[city]=Walnut&billing_address[state]=California */
+    public function testEncodeParamsWithAttributeAsSubResourceAttributesShouldConvertToURLFormEncode(): void
+    {
+        $params = [
+            "first_name" => "John",
+            "last_name" => "Doe",
+            "billing_address" =>  [
+                "city" => "Walnut",
+                "state" => "California"
+            ]
+        ];
+        $encoded = URLFormEncoder::encode($params);
+        $this->assertIsString($encoded);
+        $this->assertSame("first_name=John&last_name=Doe&billing_address%5Bcity%5D=Walnut&billing_address%5Bstate%5D=California", $encoded);
+    }
+
+    /** Should convert params to URL Form Encode */
+    /** subscription_items[item_price_id][0]=day-pass-USD&subscription_items[unit_price][0]=100&subscription_items[item_price_id][1]=basic-USD&subscription_items[billing_cycles][1]=2&subscription_items[quantity][1]=1&billing_cycle=1 */
+    public function testEncodeParamsWithAttributeAsArrayOfSubResources(): void
+    {
+        $params = [
+            "subscription_items" => [
+                [
+                    "item_price_id" => "day-pass-USD",
+                    "unit_price" => 100
+                ],
+                [
+                    "item_price_id" => "basic-USD",
+                    "billing_cycles" => 2,
+                    "quantity" => 1
+                ]
+            ],
+            "billing_cycle" => 1
+        ];
+        $encoded = URLFormEncoder::encode($params);
+        $this->assertIsString($encoded);
+        $this->assertSame("subscription_items%5Bitem_price_id%5D%5B0%5D=day-pass-USD&subscription_items%5Bunit_price%5D%5B0%5D=100&subscription_items%5Bitem_price_id%5D%5B1%5D=basic-USD&subscription_items%5Bbilling_cycles%5D%5B1%5D=2&subscription_items%5Bquantity%5D%5B1%5D=1&billing_cycle=1", $encoded);
+    }
+    /** Should convert params to URL Form Encode with that particular attributes to json string */
+    /** first_name=John&last_name=Doe&billing_address={"city":"Walnut","State":"California"} */
+    public function testEncodeParamsWithAttributeAsJsonObjectAtSameLevel(): void {
+        $params = [
+            "first_name" => "John",
+            "last_name" => "Doe",
+            "billing_address" =>  [
+                "city" => "Walnut",
+                "State" => "California"
+            ]
+        ];
+        $json_keys = [
+            "billingAddress" => 0
+        ];
+        $encoded = URLFormEncoder::encode($params, $json_keys);
+        $this->assertIsString($encoded);
+        $this->assertSame("first_name=John&last_name=Doe&billing_address=%7B%22city%22%3A%22Walnut%22%2C%22State%22%3A%22California%22%7D", $encoded);
+    }
+
+    /** Should convert params to URL Form Encode with that particular attributes to json string */
+    /** first_name=John&last_name=Doe&billing_address={"city":"Walnut","State":"California"} */
+    public function testEncodeParamsWithAttributeAsJsonStringAtSameLevel(): void {
+        $params = [
+            "first_name" => "John",
+            "last_name" => "Doe",
+            "billing_address" =>  json_encode([
+                "city" => "Walnut",
+                "State" => "California"
+            ])
+        ];
+        $json_keys = [
+            "billingAddress" => 0
+        ];
+        $encoded = URLFormEncoder::encode($params, $json_keys);
+        $this->assertIsString($encoded);
+        $this->assertSame("first_name=John&last_name=Doe&billing_address=%7B%22city%22%3A%22Walnut%22%2C%22State%22%3A%22California%22%7D", $encoded);
+    }
+
+    /** Should convert params to URL Form Encode with that particular attributes to url form encode itself as level is different */
+    /** first_name=John&last_name=Doe&billing_address[city]=Walnut&billing_address[state]=California */
+    public function testEncodeParamsWithAttributeAsJsonStringAtDifferentLevel(): void {
+        $params = [
+            "first_name" => "John",
+            "last_name" => "Doe",
+            "billing_address" =>  [
+                "city" => "Walnut",
+                "State" => "California"
+            ]
+        ];
+        $json_keys = [
+            "billingAddress" => 1
+        ];
+        $encoded = URLFormEncoder::encode($params, $json_keys);
+        $this->assertIsString($encoded);
+        $this->assertSame("first_name=John&last_name=Doe&billing_address%5Bcity%5D=Walnut&billing_address%5B_state%5D=California", $encoded);
+    }
+
+    /** Should convert params to URL Form Encode with that particular attributes to json string */
+    /** first_name=John&last_name=Doe&billing_address={"city":"Walnut","State":"California"} */
+    public function testEncodeParamsWithAttributeAsJsonObjectAndCamelCaseAtSameLevelShouldConvertAttributeToJsonString(): void {
+        $params = [
+            "first_name" => "John",
+            "last_name" => "Doe",
+            "billingAddress" =>  [
+                "city" => "Walnut",
+                "State" => "California"
+            ]
+        ];
+        $json_keys = [
+            "billingAddress" => 0
+        ];
+        $encoded = URLFormEncoder::encode($params, $json_keys);
+        $this->assertIsString($encoded);
+        $this->assertSame("first_name=John&last_name=Doe&billing_address=%7B%22city%22%3A%22Walnut%22%2C%22State%22%3A%22California%22%7D", $encoded);
+    }
+
+    /** Should convert params to URL Form Encode with that particular attributes to json string */
+    /** first_name=John&last_name=Doe&billing_address={"city":"Walnut","State":"California"} */
+    public function testEncodeParamsWithAttributeAsJsonStringAndCamelCaseAtSameLevelShouldConvertAttributeToJsonString(): void {
+        $params = [
+            "first_name" => "John",
+            "last_name" => "Doe",
+            "billingAddress" =>  json_encode([
+                "city" => "Walnut",
+                "State" => "California"
+            ])
+        ];
+        $json_keys = [
+            "billingAddress" => 0
+        ];
+        $encoded = URLFormEncoder::encode($params, $json_keys);
+        $this->assertIsString($encoded);
+        $this->assertSame("first_name=John&last_name=Doe&billing_address=%7B%22city%22%3A%22Walnut%22%2C%22State%22%3A%22California%22%7D", $encoded);
+    }
+}

--- a/tests/ValueObjects/Encoder/URLFormEncoderTest.php
+++ b/tests/ValueObjects/Encoder/URLFormEncoderTest.php
@@ -136,7 +136,7 @@ final class URLFormEncoderTest extends TestCase
 
     /** Should convert params to URL Form Encode with that particular attributes to json string */
     /** first_name=John&last_name=Doe&billing_address={"city":"Walnut","State":"California"} */
-    public function testEncodeParamsWithAttributeAsJsonObjectAndCamelCaseAtSameLevelShouldConvertAttributeToJsonString(): void {
+    public function testEncodeParamsWithAttributeAsJsonObjectAndCamelCaseAtSameLevel(): void {
         $params = [
             "first_name" => "John",
             "last_name" => "Doe",
@@ -155,7 +155,7 @@ final class URLFormEncoderTest extends TestCase
 
     /** Should convert params to URL Form Encode with that particular attributes to json string */
     /** first_name=John&last_name=Doe&billing_address={"city":"Walnut","State":"California"} */
-    public function testEncodeParamsWithAttributeAsJsonStringAndCamelCaseAtSameLevelShouldConvertAttributeToJsonString(): void {
+    public function testEncodeParamsWithAttributeAsJsonStringAndCamelCaseAtSameLevel(): void {
         $params = [
             "first_name" => "John",
             "last_name" => "Doe",


### PR DESCRIPTION
### v4.9.0 (2025-09-03)

### Bug Fixes:

* Fixed an issue where `method_exists` failed on `null` objects, which caused errors when extracting status codes. (Resolves #102)
* Corrected parameter parsing: action JSON keys use `camelCase`, but the parser did not account for this, leading to incorrect comparisons. (Resolves #97)

### Enhancements: 
* List object classes have been moved to separate files to align with `PSR-4` directory standards. (Resolves #98)
* Added `@throws` annotations in PHPDocs for all relevant exceptions.
* Added unit tests form url for encoder. 