### PR TITLE
Fixed empty json attributes arrays being sent incorrectly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### v4.12.1 (2025-12-15)
+* * * 
+
+### Bug Fixes: 
+* Fix empty json attributes arrays being sent incorrectly; now encoder encodes empty json attribute[] as {} using JSON_FORCE_OBJECT.(resolves #115)
+
 ### v4.12.0 (2025-11-26)
 * * * 
 

--- a/src/ValueObjects/Encoders/JsonParamEncoder.php
+++ b/src/ValueObjects/Encoders/JsonParamEncoder.php
@@ -14,7 +14,7 @@ class JsonParamEncoder implements ParamEncoderInterface
 
     public static function encode(array $params, array $jsonKeys = []): string
     {
-        return json_encode(self::formatJsonKeysAsSnakeCase($params));
+        return json_encode(self::formatJsonKeysAsSnakeCase($params), JSON_FORCE_OBJECT);
     }
 
     public static function formatJsonKeysAsSnakeCase($value, $maxDepth = 1000, $currentDepth = 0): array

--- a/src/ValueObjects/Encoders/URLFormEncoder.php
+++ b/src/ValueObjects/Encoders/URLFormEncoder.php
@@ -32,7 +32,7 @@ class URLFormEncoder implements ParamEncoderInterface
                 $key = (!is_null($prefix) ? $prefix : '') .
                     (!is_null($prefix) ? '[' . $usK . ']' : $usK) .
                     (!is_null($idx) ? '[' . $idx . ']' : '');
-                $serialized[$key] = is_string($v)?$v:json_encode($v);
+                $serialized[$key] = is_string($v)?$v:json_encode($v, JSON_FORCE_OBJECT);
             } else if (is_array($v) && !is_int($k)) {
                 $tempPrefix = (!is_null($prefix)) ? $prefix . '[' . Util::toUnderscoreFromCamelCase($k) . ']' : Util::toUnderscoreFromCamelCase($k);
                 $serialized = array_merge($serialized, self::serialize($v, $tempPrefix, null, $jsonKeys, $level + 1));

--- a/src/Version.php
+++ b/src/Version.php
@@ -4,7 +4,7 @@ namespace Chargebee;
 
 final class Version
 {
-	const VERSION = '4.12.0';
+	const VERSION = '4.12.1';
 }
 
 ?>

--- a/tests/ValueObjects/Encoder/URLFormEncoderTest.php
+++ b/tests/ValueObjects/Encoder/URLFormEncoderTest.php
@@ -171,4 +171,22 @@ final class URLFormEncoderTest extends TestCase
         $this->assertIsString($encoded);
         $this->assertSame("first_name=John&last_name=Doe&billing_address=%7B%22city%22%3A%22Walnut%22%2C%22State%22%3A%22California%22%7D", $encoded);
     }
+
+
+    /** Convert params to URL-form encoding. Do not transform empty arrays into associative arrays; convert them to an empty object {} instead. */
+    /** first_name=John&last_name=Doe&meta_data={}*/
+    public function testEncodeParamsWithAEmptyJsonAttribute(): void {
+        $params = [
+            "first_name" => "John",
+            "last_name" => "Doe",
+            "meta_data" =>  [
+            ]
+        ];
+        $json_keys = [
+            "metaData" => 0
+        ];
+        $encoded = URLFormEncoder::encode($params, $json_keys);
+        $this->assertIsString($encoded);
+        $this->assertSame("first_name=John&last_name=Doe&meta_data=%7B%7D", $encoded);
+    }
 }


### PR DESCRIPTION
### v4.12.1 (2025-12-15)
* * * 

### Bug Fixes: 
* Fix empty json attributes arrays being sent incorrectly; now encoder encodes empty json attribute[] as {} using JSON_FORCE_OBJECT.(resolves #115)